### PR TITLE
Add helper function to build a clean path

### DIFF
--- a/pkg/wrapper/fileutil.go
+++ b/pkg/wrapper/fileutil.go
@@ -1,0 +1,16 @@
+package wrapper
+
+import "path/filepath"
+
+func BuildCleanPath(base string, subpath string) string {
+	if filepath.IsAbs(subpath) {
+		return filepath.Clean(subpath)
+	}
+
+	if !filepath.IsAbs(base) {
+		// ignore error and use non absolute path
+		base, _ = filepath.Abs(base)
+	}
+	tmpPath := filepath.Join(base, subpath)
+	return filepath.Clean(tmpPath)
+}


### PR DESCRIPTION
This function prepends the subpath with an absolute root path if the
subpath is not already absolute. This is used to prepend the working dir
to the source and target files in the compiler wrapper.