### PR TITLE
Fix spdx analyzer

### DIFF
--- a/pkg/analysis/spdx.go
+++ b/pkg/analysis/spdx.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 
@@ -23,8 +24,12 @@ func NewSpdxAnalyzer(config map[string]string, db *database.DataBase) *SpdxAnaly
 func (spdx *SpdxAnalyzer) Analyze(node *AnalysisNode) error {
 	license, err := detectSPDXLicense(node.GetPath())
 	if err != nil {
-		node.SetLicense(database.UnknownLicense)
-		return err
+		log.Printf("Error detecting license %v", err)
+		err2 := node.SetLicense(database.UnknownLicense)
+		if err2 != nil {
+			return fmt.Errorf("failed to set license %v: %v", license, err2)
+		}
+		return nil
 	}
 
 	// TODO merge with currently set licenses

--- a/pkg/database/dgraph.go
+++ b/pkg/database/dgraph.go
@@ -119,7 +119,7 @@ func (db *DataBase) AwaitBuildComplete() {
 		if pendingInserts == 0 {
 			break
 		}
-		fmt.Printf("Pending inserts %d", pendingInserts)
+		log.Printf("Pending inserts %d", pendingInserts)
 		time.Sleep(2 * time.Second)
 	}
 }


### PR DESCRIPTION
Do not return error if file was not found and break the whole analysis.
Print a warning and set the unknown license.