### PR TITLE
Also pass stdin to the wrapped command

### DIFF
--- a/cmd/qmstr/qmstr.go
+++ b/cmd/qmstr/qmstr.go
@@ -143,6 +143,7 @@ func SetupCompilerInstrumentation(tmpWorkDir string) {
 // RunPayloadCommand performs the payload command and returns it's exit code and/or an error
 func RunPayloadCommand(command string, arguments ...string) (int, error) {
 	cmd := exec.Command(command, arguments...)
+	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	err := cmd.Run()


### PR DESCRIPTION
This makes shells work as expected (as in `qmstr bash`).