### PR TITLE
Fix deadlock if queue filled up to the maximum.

### DIFF
--- a/pkg/database/dgraph.go
+++ b/pkg/database/dgraph.go
@@ -112,7 +112,7 @@ func queueWorker(db *DataBase) {
 
 		if !ready {
 			// put node back to queue
-			db.insertQueue <- node
+			go func() { db.insertQueue <- node }()
 			continue
 		}
 


### PR DESCRIPTION
Fixes deadlock when too many nodes are submitted very fast the insert
queue buffer fills to the maximum capacity and locks the insert routine
when trying to put back a node, that is not yet ready, to the queue.