### PR TITLE
Add option to connect wrapper and cli to different address

### DIFF
--- a/cmd/qmstr-wrapper/main.go
+++ b/cmd/qmstr-wrapper/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	address  = "localhost:50051"
+	addrEnv  = "QMSTR_ADDRESS"
 	debugEnv = "QMSTR_DEBUG"
 )
 
@@ -27,6 +27,8 @@ var (
 	debug                bool
 )
 
+var address = "localhost:50051"
+
 func initLogging() {
 	var infoWriter io.Writer
 	infoWriter = wrapper.NewRemoteLogWriter(controlServiceClient)
@@ -35,6 +37,11 @@ func initLogging() {
 
 func main() {
 	_, debug = os.LookupEnv(debugEnv)
+	_, difAddress := os.LookupEnv(addrEnv)
+
+	if difAddress {
+		address = os.Getenv(addrEnv)
+	}
 	// Set up server connection
 	conn, err := grpc.Dial(address, grpc.WithInsecure())
 	if err != nil {

--- a/cmd/qmstr-wrapper/main.go
+++ b/cmd/qmstr-wrapper/main.go
@@ -1,4 +1,4 @@
-//go:generate protoc -I ../../pkg/service --go_out=plugins=grpc:../../pkg/service ../../pkg/service/datamodel.proto ../../pkg/service/buildservice.proto ../../pkg/service/controlservice.proto
+//go:generate protoc -I ../../pkg/service --go_out=plugins=grpc:../../pkg/service ../../pkg/service/datamodel.proto ../../pkg/service/analyzerservice.proto ../../pkg/service/buildservice.proto ../../pkg/service/controlservice.proto  ../../pkg/service/reportservice.proto
 package main
 
 import (

--- a/cmd/qmstr/qmstr.go
+++ b/cmd/qmstr/qmstr.go
@@ -66,9 +66,9 @@ func Run(payloadCmd []string) int {
 	}
 	defer func() {
 		if options.keepTmpDirectories {
-			Debug.Printf("keeping temporary temporary at %v", tmpWorkDir)
+			Debug.Printf("keeping temporary directory at %v", tmpWorkDir)
 		} else {
-			Debug.Printf("deleting temporary temporary instrumentation bin directory in %v", tmpWorkDir)
+			Debug.Printf("deleting temporary instrumentation bin directory in %v", tmpWorkDir)
 			if err := os.RemoveAll(tmpWorkDir); err != nil {
 				// it is a warning because the program is exiting and we cannot recover anymore
 				Log.Printf("warning - error deleting temporary instrumentation bin directory in %v: %v", tmpWorkDir, err)

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -12,10 +12,7 @@ import (
 
 var conn *grpc.ClientConn
 var controlServiceClient service.ControlServiceClient
-
-const (
-	address = "localhost:50051"
-)
+var address string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -26,6 +23,10 @@ var rootCmd = &cobra.Command{
 	and prints the version of qmstr-cli.`,
 	Run: func(cmd *cobra.Command, args []string) {
 	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&address, "cserv", "localhost:50051", "connect to control service")
 }
 
 func Execute() {
@@ -39,6 +40,7 @@ func setUpServer() {
 	// Set up server connection
 	var err error
 	conn, err = grpc.Dial(address, grpc.WithInsecure())
+	fmt.Printf("Connecting to address: %v\n", address)
 	if err != nil {
 		log.Fatalf("Failed to connect to master: %v", err)
 	}

--- a/pkg/cli/wait.go
+++ b/pkg/cli/wait.go
@@ -27,7 +27,6 @@ var waitCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(waitCmd)
 	waitCmd.Flags().IntVarP(&timeout, "timeout", "t", 60, "time is up")
-
 }
 
 func awaitServer() {


### PR DESCRIPTION
Add the option to connect to a provided address. Default is localhost:50051.

qmstr-cli also listens to the address provided by the flag 'cserv'

Needed for our demo cases