### PR TITLE
Find libraries in /lib64

### DIFF
--- a/pkg/wrapper/fileutil.go
+++ b/pkg/wrapper/fileutil.go
@@ -112,7 +112,7 @@ func FindActualLibraries(libs []string, libpath []string) ([]string, error) {
 	case "linux":
 		libprefix = "lib"
 		libsuffix = []string{".so"}
-		syslibpath = []string{"/lib", "/usr/lib", "/usr/local/lib"}
+		syslibpath = []string{"/lib", "/usr/lib", "/usr/local/lib", "/lib64"}
 	case "darwin":
 		libprefix = "lib"
 		libsuffix = []string{".dylib", ".so"}


### PR DESCRIPTION
Add /lib64 to the library lookup pathes. This is where e.g. opensuse
tumbleweed stores system libraries for 64-bit systems.