### PR TITLE
fix scancode analyzer

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -45,7 +45,9 @@ RUN mkdir /ninka && \
     rm -fr /ninka
 
 # install scancode
-RUN pip install scancode-toolkit
+COPY ci/scancode.requirements /tmp/scancode.requirements
+RUN pip install -r /tmp/requirements
+RUN rm /tmp/scancode.requirements
 
 # install dgraph
 RUN curl https://get.dgraph.io -sSf | bash
@@ -53,7 +55,7 @@ RUN curl https://get.dgraph.io -sSf | bash
 # copy qmstr installation from previous stage
 RUN mkdir -p /go/bin
 COPY --from=builder /go/bin/qmstr-master /go/bin/qmstr-master
- 
+
 EXPOSE 50051
 # dgraph ratel web ui
 EXPOSE 8000

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir /ninka && \
 
 # install scancode
 COPY ci/scancode.requirements /tmp/scancode.requirements
-RUN pip install -r /tmp/requirements
+RUN pip install -r /tmp/scancode.requirements
 RUN rm /tmp/scancode.requirements
 
 # install dgraph

--- a/ci/scancode.requirements
+++ b/ci/scancode.requirements
@@ -1,0 +1,1 @@
+scancode-toolkit==2.9.1

--- a/cmd/analyzers/scancode-analyzer/main.go
+++ b/cmd/analyzers/scancode-analyzer/main.go
@@ -48,7 +48,7 @@ func (scanalyzer *ScancodeAnalyzer) Analyze(node *service.FileNode) (*service.In
 }
 
 func scancode(workdir string, jobs int) interface{} {
-	cmdlineargs := []string{"--quiet", "--full-root"}
+	cmdlineargs := []string{"--quiet", "--full-root", "-l", "-c", "--json", "-"}
 	if jobs > 1 {
 		cmdlineargs = append(cmdlineargs, "--processes", fmt.Sprintf("%d", jobs))
 	}

--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -68,7 +68,9 @@ func (a *Analyzer) RunAnalyzerPlugin() {
 			os.Exit(master.ReturnAnalyzerFailed)
 		}
 
-		resultMap[node.Hash] = infoNodeSlice
+		if len(infoNodeSlice.Inodes) > 0 {
+			resultMap[node.Hash] = infoNodeSlice
+		}
 	}
 
 	anaresp, err := a.analysisService.SendNodes(context.Background(), &service.AnalysisMessage{ResultMap: resultMap, Token: configResp.Token})

--- a/pkg/database/dgraph.go
+++ b/pkg/database/dgraph.go
@@ -91,6 +91,7 @@ func (db *DataBase) AddNode(node *service.FileNode) {
 	db.insertQueue <- node
 }
 
+// the queueWorker runs in a go routine and inserts the nodes from the insert queue into the database
 func queueWorker(db *DataBase) {
 	for node := range db.insertQueue {
 		ready := true

--- a/pkg/master/analyze.go
+++ b/pkg/master/analyze.go
@@ -1,14 +1,11 @@
 package master
 
 import (
-	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"log"
 	"math/rand"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/QMSTR/qmstr/pkg/config"
@@ -46,13 +43,7 @@ func (phase *serverPhaseAnalysis) Activate() error {
 		cmd := exec.Command(analyzerName, "--aserv", phase.rpcAddress, "--aid", fmt.Sprintf("%d", idx))
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			var buffer bytes.Buffer
-			buffer.WriteString(fmt.Sprintf("Analyzer %s failed with:\n", analyzerName))
-			s := bufio.NewScanner(strings.NewReader(string(out)))
-			for s.Scan() {
-				buffer.WriteString(fmt.Sprintf("\t--> %s\n", s.Text()))
-			}
-			log.Println(buffer.String())
+			logPluginError(analyzerName, out)
 			return err
 		}
 		log.Printf("Analyzer %s finished successfully: %s\n", analyzerName, out)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -1,10 +1,13 @@
 package master
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"log"
 	"net"
+	"strings"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -159,4 +162,14 @@ func InitAndRun(configfile string) error {
 		return fmt.Errorf("Failed to start rpc service %v", err)
 	}
 	return nil
+}
+
+func logPluginError(pluginName string, output []byte) {
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("%s failed with:\n", pluginName))
+	s := bufio.NewScanner(strings.NewReader(string(output)))
+	for s.Scan() {
+		buffer.WriteString(fmt.Sprintf("\t--> %s\n", s.Text()))
+	}
+	log.Println(buffer.String())
 }

--- a/pkg/master/report.go
+++ b/pkg/master/report.go
@@ -23,7 +23,7 @@ func (phase *serverPhaseReport) Activate() error {
 		cmd := exec.Command(reporterName, "--rserv", phase.rpcAddress, "--rid", fmt.Sprintf("%d", idx))
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Printf("Reporter %s failed with: %s\n", reporterName, out)
+			logPluginError(reporterName, out)
 			return err
 		}
 		log.Printf("Reporter %s finished successfully: %s\n", reporterName, out)


### PR DESCRIPTION
When scancode fails to read a file it returns a non-zero return code even though a scan result is produced that can be used. To work around this behavior we do not only check the return code but the status message from stderr as well.