### PR TITLE
Export environment variable QMSTR_INSTRUMENTATION_HOME.

### DIFF
--- a/cmd/qmstr/qmstr.go
+++ b/cmd/qmstr/qmstr.go
@@ -135,8 +135,11 @@ func SetupCompilerInstrumentation(tmpWorkDir string) {
 	newPath := strings.Join(paths, separator)
 	os.Setenv("PATH", newPath)
 	Debug.Printf("PATH is now %v\n", os.Getenv("PATH"))
+	os.Setenv("QMSTR_INSTRUMENTATION_HOME", tmpWorkDir)
+	Debug.Printf("QMSTR_INSTRUMENTATION_HOME is now %v\n", os.Getenv("QMSTR_INSTRUMENTATION_HOME"))
 	if options.keepTmpDirectories {
 		fmt.Printf("export PATH=%v\n", os.Getenv("PATH"))
+		fmt.Printf("export QMSTR_INSTRUMENTATION_HOME=%v\n", os.Getenv("QMSTR_INSTRUMENTATION_HOME"))
 	}
 }
 


### PR DESCRIPTION
It points to where the bin/ directory is that contains the wrapper links.