### PR TITLE
hotfix protobuf deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/dgraph-io/dgo"
   packages = [
@@ -30,6 +36,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-version"
+  packages = ["."]
+  revision = "23480c0665776210b5fbbac6eaaee40e3e6a96b7"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -42,6 +54,12 @@
   version = "v0.8.0"
 
 [[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
@@ -52,6 +70,15 @@
   packages = ["."]
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require"
+  ]
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
@@ -132,6 +159,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2d9b18f6feca2a07c8d254f0ae572132a646deb6c1b59b3e58ba7e5ec9307a35"
+  inputs-digest = "7581b0cb3d1dcf05e975e8bbc37a6f92fa26df350a713fda62e6eb1fee33d5ef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,8 +32,8 @@
     "ptypes/duration",
     "ptypes/timestamp"
   ]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -159,6 +159,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7581b0cb3d1dcf05e975e8bbc37a6f92fa26df350a713fda62e6eb1fee33d5ef"
+  inputs-digest = "5f1da65fce55617121bec38a97d1f2fe79dd0a8376de5236f9e995ac50f7acb0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,18 +15,24 @@
     "protos/api",
     "y"
   ]
-  revision = "939c270eac93a70e63162abd53f78dbc9e928ff6"
+  revision = "5b24712f09e4b8db0c72e2af55a44885dfd2855b"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
-  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
-  version = "v0.5"
+  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
+    "protoc-gen-go",
+    "protoc-gen-go/descriptor",
+    "protoc-gen-go/generator",
+    "protoc-gen-go/generator/internal/remap",
+    "protoc-gen-go/grpc",
+    "protoc-gen-go/plugin",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
@@ -62,14 +68,14 @@
 [[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
-  version = "v0.0.1"
+  revision = "a1f051bc3eba734da4772d60e2d677f47cf93ef4"
+  version = "v0.0.2"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -85,6 +91,7 @@
   name = "golang.org/x/net"
   packages = [
     "context",
+    "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
@@ -92,10 +99,9 @@
     "lex/httplex",
     "trace"
   ]
-  revision = "b417086c80e91bfa321ef761574721644b8b9f61"
+  revision = "5f9ae10d9af5b1c89ae6904293b14b064d4ada23"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -113,13 +119,14 @@
     "unicode/norm",
     "unicode/rangetable"
   ]
-  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
+  revision = "86e600f69ee4704c6efbf6a2a40a5c10700e76c2"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -132,6 +139,7 @@
     "connectivity",
     "credentials",
     "encoding",
+    "encoding/proto",
     "grpclb/grpc_lb_v1/messages",
     "grpclog",
     "internal",
@@ -147,18 +155,18 @@
     "tap",
     "transport"
   ]
-  revision = "6b51017f791ae1cfbec89c52efdf444b13b550ef"
-  version = "v1.9.2"
+  revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
+  version = "v1.11.3"
 
 [[projects]]
-  branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5f1da65fce55617121bec38a97d1f2fe79dd0a8376de5236f9e995ac50f7acb0"
+  inputs-digest = "12cc1ea0241535dd1c3d5fad4cdcd00df0e46c4d2d4c8ff5b93fecc160d5974d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,7 @@
 #   go-tests = true
 #   unused-packages = true
 
+required = ["github.com/golang/protobuf/protoc-gen-go"]
 
 [[constraint]]
   name = "github.com/dgraph-io/dgo"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/golang/protobuf"
-  version = "1.0.0"
+  version = "1.1.0"
 
 [[constraint]]
   name = "github.com/spf13/pflag"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,27 +12,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # install golang tools
-RUN go get -u github.com/golang/protobuf/protoc-gen-go && \
-    go get -u github.com/golang/dep/cmd/dep
-
 RUN mkdir -p ${GOPATH}/src/github.com/QMSTR/qmstr && \
     mkdir ${GOPATH}/src/github.com/QMSTR/qmstr/cmd && \
     mkdir ${GOPATH}/src/github.com/QMSTR/qmstr/pkg
 ADD cmd ${GOPATH}/src/github.com/QMSTR/qmstr/cmd
 ADD pkg ${GOPATH}/src/github.com/QMSTR/qmstr/pkg
 COPY Gopkg.* ${GOPATH}/src/github.com/QMSTR/qmstr/
+COPY install.sh /tmp/install-qmstr.sh
 
-RUN cd $GOPATH/src/github.com/QMSTR/qmstr && \
-    dep ensure
-RUN go generate github.com/QMSTR/qmstr/cmd/qmstr-master
-RUN go install github.com/QMSTR/qmstr/cmd/qmstr-master && \
-    go install github.com/QMSTR/qmstr/cmd/qmstr-wrapper && \
-    go install github.com/QMSTR/qmstr/cmd/qmstr-cli && \
-    go install github.com/QMSTR/qmstr/cmd/qmstr
-
-RUN go install github.com/QMSTR/qmstr/cmd/analyzers/spdx-analyzer && \
-    go install github.com/QMSTR/qmstr/cmd/analyzers/scancode-analyzer && \
-    go install github.com/QMSTR/qmstr/cmd/qmstr-reporter-html
+RUN chmod +x /tmp/install-qmstr.sh
+RUN /tmp/install-qmstr.sh
 
 # separate stage just to run the master unit tests:
 FROM builder as master_unit_tests

--- a/install.sh
+++ b/install.sh
@@ -16,4 +16,8 @@ go install github.com/QMSTR/qmstr/cmd/qmstr-master
 go install github.com/QMSTR/qmstr/cmd/qmstr-wrapper
 go install github.com/QMSTR/qmstr/cmd/qmstr-cli
 go install github.com/QMSTR/qmstr/cmd/qmstr
+go install github.com/QMSTR/qmstr/cmd/analyzers/spdx-analyzer
+go install github.com/QMSTR/qmstr/cmd/analyzers/scancode-analyzer
+go install github.com/QMSTR/qmstr/cmd/qmstr-reporter-html
+
 echo Done.

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
-go get -u github.com/golang/protobuf/protoc-gen-go
 go get -u github.com/golang/dep/cmd/dep
 
 go get -u github.com/QMSTR/qmstr
-(cd $GOPATH/src/github.com/QMSTR/qmstr; dep ensure)
+pushd $GOPATH/src/github.com/QMSTR/qmstr
+dep ensure
+pushd vendor/github.com/golang/protobuf/protoc-gen-go
+go install
+
+popd
+popd
+
 go generate github.com/QMSTR/qmstr/cmd/qmstr-master
 
 go install github.com/QMSTR/qmstr/cmd/qmstr-master


### PR DESCRIPTION
The golang protobuf compiler plugin changed and therefor the new protobuf lib is needed to compile the generated code.