### PR TITLE
speedup pex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ devcontainer: container
 pyqmstr-spdx-analyzer: $(QMSTR_PYTHON_SPDX_ANALYZER)
 
 $(QMSTR_PYTHON_SPDX_ANALYZER): python_proto
-	venv/bin/pex ./python/pyqmstr ./python/spdx-analyzer -e spdxanalyzer.__main__:main -o $@
+	venv/bin/pex ./python/pyqmstr ./python/spdx-analyzer -f /tmp/wheelhouse -e spdxanalyzer.__main__:main -o $@
 
 python_modules: $(QMSTR_PYTHON_MODULES)
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -131,6 +131,8 @@ RUN /usr/local/bin/install-qmstr.sh -d
 
 VOLUME /go/src
 
+COPY --from=builder /root/.pex/build/grpcio-1.11.0*.whl /tmp/wheelhouse/
+
 COPY ci/dev-entrypoint.sh /dev-entrypoint.sh
 RUN chmod +x /dev-entrypoint.sh
 ENTRYPOINT [ "/dev-entrypoint.sh" ]


### PR DESCRIPTION
Speed up pexing in dev container by using grpcio python wheel to avoid recompiling the grpc C code.