### PR TITLE
Fix qmstrctl logging setup

### DIFF
--- a/cmd/qmstr-wrapper/main.go
+++ b/cmd/qmstr-wrapper/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	addrEnv  = "QMSTR_ADDRESS"
+	addrEnv  = "QMSTR_MASTER"
 	debugEnv = "QMSTR_DEBUG"
 )
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -30,11 +30,11 @@ var rootCmd = &cobra.Command{
 	Short: "qmstrctl controls and manages the Quartermaster master",
 	Long: `qmstrctl controls and manages the Quartermaster master process.
 	It provides commands to run, quit and configure the master.`,
-	Run:              func(cmd *cobra.Command, args []string) {},
-	PersistentPreRun: SetupPersistentVariables,
+	Run: func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {
+	SetupLogging()
 	rootCmd.PersistentFlags().StringVar(&address, "cserv", "", "connect to control service")
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "enable diagnostics")
 }
@@ -68,8 +68,8 @@ func tearDownServer() {
 	conn.Close()
 }
 
-// SetupPersistentVariables sets up logging
-func SetupPersistentVariables(cmd *cobra.Command, args []string) {
+// SetupLogging sets up logging
+func SetupLogging() {
 	log := logging.Setup(verbose)
 	Debug = log.Debug
 	Log = log.Log


### PR DESCRIPTION
Setup logging via init. Otherwise SIGSEGV will be the result when
providing unknown flag duei access to uninitialized logger.