### PR TITLE
fix wait when starting

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -68,7 +68,7 @@ func startMaster(cmd *cobra.Command, args []string) {
 		Log.Fatalf("Starting qmstr-master failed: %v", err)
 	}
 
-	var address = fmt.Sprintf("%s:%s", portBinding.HostIP, portBinding.HostPort)
+	address = fmt.Sprintf("%s:%s", portBinding.HostIP, portBinding.HostPort)
 
 	if wait {
 		setUpServer()


### PR DESCRIPTION
set the right address variable to wait for the master on start command