### PR TITLE
#58 Normalised ranking of info nodes

### DIFF
--- a/cmd/analyzers/scancode-analyzer/main.go
+++ b/cmd/analyzers/scancode-analyzer/main.go
@@ -172,10 +172,10 @@ func (scanalyzer *ScancodeAnalyzer) detectLicenses(srcFilePath string) ([]*servi
 						Data: spdxIdent,
 					})
 				}
-
 				licenseNodes = append(licenseNodes, &service.InfoNode{
-					Type:      "license",
-					DataNodes: tempDataNodes,
+					Type:            "license",
+					ConfidenceScore: license["score"].(float64) / 100,
+					DataNodes:       tempDataNodes,
 				})
 			}
 			return licenseNodes, nil

--- a/pkg/master/analyze.go
+++ b/pkg/master/analyze.go
@@ -126,6 +126,7 @@ func (phase *serverPhaseAnalysis) SendNodes(in *service.AnalysisMessage) (*servi
 			// prevent inserting data nodes twice
 			infoNode.DataNodes = nil
 			infoNode.Analyzer = append(infoNode.Analyzer, phase.currentAnalyzer)
+			infoNode.ConfidenceScore = inode.ConfidenceScore
 
 			inodes.Inodes[idx] = infoNode
 		}

--- a/proto/datamodel.proto
+++ b/proto/datamodel.proto
@@ -17,14 +17,15 @@ message InfoNode {
     string uid = 1;
     int32 nodeType = 2;
     string type = 3;
-    repeated Analyzer analyzer = 4;
+    double confidenceScore = 4;
+    repeated Analyzer analyzer = 5;
 
     message DataNode {
         int32 nodeType = 1;
         string type = 2;
         string data = 3;
     }
-    repeated DataNode dataNodes = 5;
+    repeated DataNode dataNodes = 6;
 }
 
 message Analyzer {


### PR DESCRIPTION
Confidence score is used as a normalised ranking of info nodes.

Issue: https://github.com/QMSTR/qmstr-all/issues/58