### PR TITLE
Check type selector in the configuration

### DIFF
--- a/cmd/analyzers/pkg-analyzer/main.go
+++ b/cmd/analyzers/pkg-analyzer/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/QMSTR/qmstr/pkg/service"
 )
 
-const queryType = "linkedtarget"
+var queryType = "linkedtarget"
 
 type PkgAnalyzer struct {
 	targetsSlice []string
@@ -42,6 +42,9 @@ func (pkganalyzer *PkgAnalyzer) Configure(configMap map[string]string) error {
 	}
 	pkganalyzer.targetsDir = configMap["targetdir"]
 
+	if typeSelector, ok := configMap["selector"]; ok {
+		queryType = typeSelector
+	}
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,6 @@ import (
 type Analysis struct {
 	Name       string `yaml:"name"`
 	PosixName  string
-	Selector   string
 	Analyzer   string
 	TrustLevel int64
 	PathSub    []*service.PathSubstitution

--- a/pkg/master/analyze.go
+++ b/pkg/master/analyze.go
@@ -99,7 +99,7 @@ func (phase *serverPhaseAnalysis) GetAnalyzerConfig(in *service.AnalyzerConfigRe
 		config.PathSub = phase.masterConfig.Server.PathSub
 	}
 	phase.currentAnalyzer.PathSub = config.PathSub
-	return &service.AnalyzerConfigResponse{ConfigMap: config.Config, TypeSelector: config.Selector, PathSub: config.PathSub,
+	return &service.AnalyzerConfigResponse{ConfigMap: config.Config, PathSub: config.PathSub,
 		Token: phase.currentToken, Name: config.Name, Session: phase.session}, nil
 }
 
@@ -159,6 +159,9 @@ func (phase *serverPhaseAnalysis) GetFileNode(in *service.FileNode, stream servi
 		return err
 	}
 	nodeFiles, err := db.GetFileNodesByFileNode(in, true)
+	if err != nil {
+		return err
+	}
 
 	for _, nodeFile := range nodeFiles {
 		for _, substitution := range phase.currentAnalyzer.PathSub {

--- a/proto/analyzerservice.proto
+++ b/proto/analyzerservice.proto
@@ -8,7 +8,6 @@ message AnalyzerConfigRequest {
 }
 
 message AnalyzerConfigResponse {
-    string typeSelector = 1;
     map<string, string> configMap = 2;
     repeated PathSubstitution pathSub = 3;
     int64 token = 4;


### PR DESCRIPTION
Package analyzer connects the package node with linked targets but in the case of jabref we
want to connect the package node to a jar file. In that case we provide a type selector to
override the default type.