### PR TITLE
Distinguish between rpc failure and modules failure

### DIFF
--- a/pkg/cli/phasecontrol.go
+++ b/pkg/cli/phasecontrol.go
@@ -50,7 +50,7 @@ func startPhase(phase int32) {
 		os.Exit(ReturnCodeServerCommunicationError)
 	}
 	if !resp.Success {
-		fmt.Println("Server responded unsuccessful")
+		fmt.Printf("Server reported failure:\n%s\n", resp.Error)
 		os.Exit(ReturnCodeResponseFalseError)
 	}
 }

--- a/pkg/master/analyze.go
+++ b/pkg/master/analyze.go
@@ -51,8 +51,9 @@ func (phase *serverPhaseAnalysis) Activate() error {
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			logModuleError(analyzerName, out)
-			phase.server.publishEvent(&service.Event{Class: string(EventModule), Message: fmt.Sprintf("Analyzer %s failed", analyzerName)})
-			return err
+			errMsg := fmt.Sprintf("Analyzer %s failed", analyzerName)
+			phase.server.publishEvent(&service.Event{Class: string(EventModule), Message: errMsg})
+			return errors.New(errMsg)
 		}
 		phase.server.publishEvent(&service.Event{Class: string(EventModule), Message: fmt.Sprintf("Analyzer %s successfully finished", analyzerName)})
 		log.Printf("Analyzer %s finished successfully: %s\n", analyzerName, out)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -97,7 +97,7 @@ func (s *server) SwitchPhase(ctx context.Context, in *service.SwitchPhaseMessage
 	requestedPhase := in.Phase
 	err := s.switchPhase(requestedPhase)
 	if err != nil {
-		return &service.SwitchPhaseResponse{Success: false}, err
+		return &service.SwitchPhaseResponse{Success: false, Error: err.Error()}, nil
 	}
 	return &service.SwitchPhaseResponse{Success: true}, nil
 }

--- a/proto/controlservice.proto
+++ b/proto/controlservice.proto
@@ -25,6 +25,7 @@ message SwitchPhaseMessage {
 
 message SwitchPhaseResponse {
   bool success = 1;
+  string error = 2;
 }
 
 message PackageRequest {


### PR DESCRIPTION
Print out better failure messages and publish more events to improve
feedback to the user.