### PR TITLE
Fix Hugo dectection in latest versions.

### DIFF
--- a/pkg/module/reporter/htmlreporter/htmlreporter.go
+++ b/pkg/module/reporter/htmlreporter/htmlreporter.go
@@ -169,7 +169,7 @@ func ParseVersion(output []byte) (string, error) {
 		return version, nil
 	}
 
-	re = regexp.MustCompile("Site Generator v(.+) .+/.+ BuildDate")
+	re = regexp.MustCompile("Site Generator v(.+) .+/.+")
 	match = re.FindSubmatch(output)
 	if match != nil {
 		version := strings.TrimSpace(string(match[1][:]))


### PR DESCRIPTION
At least the version installed by Homebrew does not contain the
"BuildDate" part in the version string anymore.