### PR TITLE
Introduce debugging again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ requirements.txt:
 	echo pex >> requirements.txt
 	echo autopep8 >> requirements.txt
 
-
 go_proto: $(PROTOC_GEN_GO)
 	protoc -I proto --go_out=plugins=grpc:pkg/service proto/*.proto
 

--- a/ci/dev-entrypoint.sh
+++ b/ci/dev-entrypoint.sh
@@ -16,9 +16,9 @@ start_dgraph_web
 
 create_qmstr_user
 
-if [ -z "$QMSTR_DEV" ]; then
+if [ -z "$QMSTR_DEBUG" ]; then
     start_qmstr
 else
     echo "Running debug session"
-    exec dlv debug github.com/QMSTR/qmstr/cmd/qmstr-master -l 0.0.0.0:2345 --headless=true --log=true -- --config /buildroot/qmstr.yaml ${PATH_SUB:+--pathsub="$PATH_SUB"}
+    exec dlv debug github.com/QMSTR/qmstr/cmd/qmstr-master -l 0.0.0.0:2345 --headless=true --log=true -- --config /qmstr/qmstr.yaml ${PATH_SUB:+--pathsub="$PATH_SUB"}
 fi

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,7 +36,10 @@ type ServerConfig struct {
 	DBWorkers  int
 	CacheDir   string
 	OutputDir  string
-	ImageName  string
+	ImageName  string `yaml:"image"`
+	Debug      bool
+	ExtraEnv   map[string]string
+	ExtraMount map[string]string
 	PathSub    []*service.PathSubstitution
 }
 
@@ -57,7 +60,9 @@ func getDefaultConfig() *QmstrConfig {
 		Package: &MasterConfig{
 			// TODO make default output and cache dir platform independent
 			Server: &ServerConfig{DBWorkers: 2, RPCAddress: ":50051", DBAddress: "localhost:9080",
-				CacheDir: "/var/cache/qmstr", OutputDir: "/var/qmstr"},
+				CacheDir: "/var/cache/qmstr", OutputDir: "/var/qmstr",
+				ExtraEnv: map[string]string{}, ExtraMount: map[string]string{},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Allow running a debug image. Therefore the container needs special
permissions to run qmstr-mastr via dlv.

In order to run a debug session the qmstr.yaml needs to specify a
development container image and set debug to true e.g.

package:
    name: debug
    metadata:
        .
        .
        .
    server:
        .
        .
        .
        image: qmstr/dev
        debug: True