### PR TITLE
moving output to host

### DIFF
--- a/pkg/cli/copy.go
+++ b/pkg/cli/copy.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/QMSTR/qmstr/pkg/config"
+	"github.com/QMSTR/qmstr/pkg/docker"
+	"github.com/docker/docker/client"
+
+	"golang.org/x/net/context"
+
+	"github.com/spf13/cobra"
+)
+
+var copyCmd = &cobra.Command{
+	Use:   "copy",
+	Short: "Copy results from qmstr",
+	Long:  `Copy report results from qmstr server.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		copyResults()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(copyCmd)
+}
+
+func copyResults() {
+	ctx := context.Background()
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		Log.Fatalf("Failed to create docker client %v", err)
+	}
+	mID, _, err := docker.GetMasterInfo(ctx, cli)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	configdata, err := docker.GetMasterConfig(ctx, cli, mID)
+	if err != nil {
+		Log.Fatalf("Can not load master configuration from container : %v", err)
+	}
+	Debug.Printf("Got config from master: %s", configdata)
+	config, err := config.ReadConfig(configdata)
+	if err != nil {
+		Log.Fatalf("Can not read master configuration from container : %v", err)
+	}
+
+	outdir := config.Server.OutputDir
+	if outdir == "" {
+		var err error
+		outdir, err = os.Getwd()
+		if err != nil {
+			Log.Fatalf("unable to determine current working directory")
+		}
+		outdir = filepath.Join(outdir, "qmstr")
+	}
+
+	Debug.Printf("writing results to %s", outdir)
+	docker.CopyResults(ctx, cli, mID, outdir)
+}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -38,18 +38,28 @@ var configFile string
 var wait bool
 var debug bool
 
+func getConfig() (*config.MasterConfig, error) {
+	var err error
+	configFile, err = filepath.Abs(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := config.ReadConfigFromFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
 func startMaster(cmd *cobra.Command, args []string) {
 	wd, err := os.Getwd()
 	if err != nil {
 		Log.Fatalf("unable to determine current working directory")
 	}
 
-	configFile, err = filepath.Abs(configFile)
-	if err != nil {
-		Log.Fatalf("unable to get absolute config path")
-	}
-
-	config, err := config.ReadConfigFromFile(configFile)
+	config, err := getConfig()
 	if err != nil {
 		Log.Fatalf("failed to read configuration %v", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,10 +70,10 @@ func ReadConfigFromFile(configfile string) (*MasterConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	return readConfig(data)
+	return ReadConfig(data)
 }
 
-func readConfig(data []byte) (*MasterConfig, error) {
+func ReadConfig(data []byte) (*MasterConfig, error) {
 	configuration := getDefaultConfig()
 	err := yaml.Unmarshal(data, configuration)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,7 +57,6 @@ type QmstrConfig struct {
 func getDefaultConfig() *QmstrConfig {
 	return &QmstrConfig{
 		Package: &MasterConfig{
-			// TODO make default output and cache dir platform independent
 			Server: &ServerConfig{DBWorkers: 2, RPCAddress: ":50051", DBAddress: "localhost:9080",
 				ExtraEnv: map[string]string{}, ExtraMount: map[string]string{},
 			},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,6 @@ type ServerConfig struct {
 	RPCAddress string
 	DBAddress  string
 	DBWorkers  int
-	CacheDir   string
 	OutputDir  string
 	ImageName  string `yaml:"image"`
 	Debug      bool
@@ -60,7 +59,6 @@ func getDefaultConfig() *QmstrConfig {
 		Package: &MasterConfig{
 			// TODO make default output and cache dir platform independent
 			Server: &ServerConfig{DBWorkers: 2, RPCAddress: ":50051", DBAddress: "localhost:9080",
-				CacheDir: "/var/cache/qmstr", OutputDir: "/var/qmstr",
 				ExtraEnv: map[string]string{}, ExtraMount: map[string]string{},
 			},
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,7 +41,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := readConfig([]byte(config))
+	_, err := ReadConfig([]byte(config))
 	if err != nil {
 		t.Logf("Broken config %v", err)
 		t.Fail()
@@ -84,7 +84,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := readConfig([]byte(config))
+	_, err := ReadConfig([]byte(config))
 	if err == nil || err.Error() != "1. reporter misconfigured Name invalid" {
 		t.Log(err)
 		t.Fail()
@@ -128,7 +128,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := readConfig([]byte(config))
+	_, err := ReadConfig([]byte(config))
 	if err == nil || err.Error() != "2. analyzer misconfigured duplicate value of The Testalyzer in Name" {
 		t.Log(err)
 		t.Fail()
@@ -171,7 +171,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := readConfig([]byte(config))
+	_, err := ReadConfig([]byte(config))
 	if err == nil || err.Error() != "1. analyzer misconfigured Analyzer invalid" {
 		t.Log(err)
 		t.Fail()
@@ -213,7 +213,7 @@ package:
     - config:
         tester: "Endocode"
 `
-	_, err := readConfig([]byte(config))
+	_, err := ReadConfig([]byte(config))
 	if err == nil || err.Error() != "1. reporter misconfigured Name invalid" {
 		t.Log(err)
 		t.Fail()
@@ -257,7 +257,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := readConfig([]byte(config))
+	_, err := ReadConfig([]byte(config))
 	if err == nil || err.Error() != "2. analyzer misconfigured duplicate value of The_Testalyzer in PosixName" {
 		t.Log(err)
 		t.Fail()
@@ -292,7 +292,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := readConfig([]byte(config))
+	_, err := ReadConfig([]byte(config))
 	if err == nil || err.Error() != "Invalid RPC address" {
 		t.Log(err)
 		t.Fail()

--- a/pkg/docker/copy.go
+++ b/pkg/docker/copy.go
@@ -1,0 +1,26 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/QMSTR/qmstr/pkg/master"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/archive"
+)
+
+func copyResults(ctx context.Context, cli *client.Client, container string, destinationPath string) error {
+
+	data, stat, err := cli.CopyFromContainer(ctx, container, master.ServerOutputDir)
+	if err != nil {
+		return err
+	}
+	defer data.Close()
+
+	srcInfo := archive.CopyInfo{
+		Path:   master.ServerOutputDir,
+		Exists: true,
+		IsDir:  stat.Mode.IsDir(),
+	}
+
+	return archive.CopyTo(data, srcInfo, destinationPath)
+}

--- a/pkg/docker/copy.go
+++ b/pkg/docker/copy.go
@@ -1,15 +1,17 @@
 package docker
 
 import (
+	"bytes"
 	"context"
+	"io/ioutil"
+	"regexp"
 
 	"github.com/QMSTR/qmstr/pkg/master"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 )
 
-func copyResults(ctx context.Context, cli *client.Client, container string, destinationPath string) error {
-
+func CopyResults(ctx context.Context, cli *client.Client, container string, destinationPath string) error {
 	data, stat, err := cli.CopyFromContainer(ctx, container, master.ServerOutputDir)
 	if err != nil {
 		return err
@@ -23,4 +25,24 @@ func copyResults(ctx context.Context, cli *client.Client, container string, dest
 	}
 
 	return archive.CopyTo(data, srcInfo, destinationPath)
+}
+
+func GetMasterConfig(ctx context.Context, cli *client.Client, container string) ([]byte, error) {
+	data, _, err := cli.CopyFromContainer(ctx, container, "/qmstr/qmstr.yaml")
+	if err != nil {
+		return nil, err
+	}
+	defer data.Close()
+
+	config, err := ioutil.ReadAll(data)
+	if err != nil {
+		return nil, err
+	}
+
+	// poor man's untar this might be replaced by a proper untar function
+	tarPattern := regexp.MustCompile("^.*package:")
+	config = tarPattern.ReplaceAll(config, []byte("package:"))
+	config = bytes.Trim(config, "\x00")
+
+	return config, nil
 }

--- a/pkg/master/analyze.go
+++ b/pkg/master/analyze.go
@@ -86,15 +86,9 @@ func (phase *serverPhaseAnalysis) GetAnalyzerConfig(in *service.AnalyzerConfigRe
 	}
 
 	config.Config["name"] = config.Name
+	config.Config["cachedir"] = filepath.Join(ServerCacheDir, config.Analyzer, config.PosixName)
+	config.Config["outputdir"] = filepath.Join(ServerOutputDir, config.Analyzer, config.PosixName)
 
-	// Set cachedir, if not overriden
-	if _, ok := config.Config["cachedir"]; !ok {
-		config.Config["cachedir"] = filepath.Join(phase.masterConfig.Server.CacheDir, config.Analyzer, config.PosixName)
-	}
-	// Set output dir, if not overriden
-	if _, ok := config.Config["outputdir"]; !ok {
-		config.Config["outputdir"] = filepath.Join(phase.masterConfig.Server.OutputDir, config.Analyzer, config.PosixName)
-	}
 	// Set path substitution, if not overriden
 	if config.PathSub == nil || len(config.PathSub) == 0 {
 		config.PathSub = phase.masterConfig.Server.PathSub

--- a/pkg/master/constants.go
+++ b/pkg/master/constants.go
@@ -17,3 +17,6 @@ const (
 	PhaseIDReport
 	PhaseIDFailure
 )
+
+const ServerCacheDir string = "/var/cache/qmstr"
+const ServerOutputDir string = "/var/qmstr"

--- a/pkg/master/report.go
+++ b/pkg/master/report.go
@@ -64,15 +64,8 @@ func (phase *serverPhaseReport) GetReporterConfig(in *service.ReporterConfigRequ
 	}
 
 	config.Config["name"] = config.Name
-
-	// Set cachedir, if not overriden
-	if _, ok := config.Config["cachedir"]; !ok {
-		config.Config["cachedir"] = filepath.Join(phase.masterConfig.Server.CacheDir, config.Reporter, config.PosixName)
-	}
-	// Set output dir, if not overriden
-	if _, ok := config.Config["outputdir"]; !ok {
-		config.Config["outputdir"] = filepath.Join(phase.masterConfig.Server.OutputDir, config.Reporter, config.PosixName)
-	}
+	config.Config["cachedir"] = filepath.Join(ServerCacheDir, config.Reporter, config.PosixName)
+	config.Config["outputdir"] = filepath.Join(ServerOutputDir, config.Reporter, config.PosixName)
 
 	return &service.ReporterConfigResponse{ConfigMap: config.Config, Session: phase.session,
 		Name: config.Name}, nil


### PR DESCRIPTION
Moving results to host on quit.

WARN:This redefines outputdir in qmstr.yaml to be the host destination!

refs https://github.com/QMSTR/qmstr-all/issues/104