### PR TITLE
Add a step to force cleaning the repository before starting.

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
     stages {
         stage('DocTest') {
             steps {
+	    	sh 'git clean -fxd'
                 sh 'vagrant up'
                 sh 'vagrant ssh -c /vagrant/ci/vagrant-test-documentation-driver.sh'
             }


### PR DESCRIPTION
Since Jenkins does not do it by default... which is weird.