### PR TITLE
Increase Vagrant VM memory with Virtualbox.

### DIFF
--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -6,4 +6,8 @@ Vagrant.configure("2") do |config|
     config.vm.synced_folder ".", "/vagrant", type: "nfs"
   end
   config.vm.provision :shell, path: "ci/vagrant-bootstrap.sh"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+  end
 end


### PR DESCRIPTION
This fixes the crashes in the analysis phase of the tutorials in the
doc tests. The VM runs out of memory.