### PR TITLE
Use the super strict form of "git clean" to get really clean.

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     stages {
         stage('DocTest') {
             steps {
-	    	sh 'git clean -fxd'
+	    	sh 'git clean -ffxd'
                 sh 'vagrant up'
                 sh 'vagrant ssh -c /vagrant/ci/vagrant-test-documentation-driver.sh'
             }


### PR DESCRIPTION
Otherwise, git skips repositories, and leaves our `json-c` example
repo in place.