### PR TITLE
global config

### DIFF
--- a/ci/common.inc
+++ b/ci/common.inc
@@ -1,9 +1,11 @@
 function create_dirs() {
     if [ -n ${USERID} ]; then
         for i in /var/cache/qmstr /var/qmstr /var/lib/qmstr; do
-            echo "Creating dir $i to be owned by ${USERID}"
-            mkdir ${i}
-            chown ${USERID} ${i}
+            if [ ! -d "${i}" ]; then
+                echo "Creating dir $i to be owned by ${USERID}"
+                mkdir ${i}
+                chown ${USERID} ${i}
+            fi
         done
     fi
 }

--- a/cmd/qmstr-master/main.go
+++ b/cmd/qmstr-master/main.go
@@ -15,7 +15,7 @@ func main() {
 	flag.StringSliceVar(&pathSubstitution, "pathsub", nil, "Set path substitution e.g. old,new")
 	flag.Parse()
 
-	masterConfig, err := config.ReadConfigFromFile(*configFile)
+	masterConfig, err := config.ReadConfigFromFiles(*configFile)
 	if err != nil {
 		log.Fatalf("Failed to read configuration %v", err)
 	}

--- a/pkg/cli/copy.go
+++ b/pkg/cli/copy.go
@@ -38,12 +38,12 @@ func copyResults() {
 		log.Fatal(err)
 	}
 
-	configdata, err := docker.GetMasterConfig(ctx, cli, mID)
+	configdata, err := docker.GetMasterConfig(ctx, cli, mID, internalConfigPath)
 	if err != nil {
 		Log.Fatalf("Can not load master configuration from container : %v", err)
 	}
 	Debug.Printf("Got config from master: %s", configdata)
-	config, err := config.ReadConfig(configdata)
+	config, err := config.ReadConfigFromBytes(configdata)
 	if err != nil {
 		Log.Fatalf("Can not read master configuration from container : %v", err)
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/QMSTR/qmstr/pkg/master"
+
 	"github.com/QMSTR/qmstr/pkg/config"
 	"github.com/QMSTR/qmstr/pkg/docker"
 	"github.com/docker/docker/api/types"
@@ -201,6 +203,10 @@ func startContainer(ctx context.Context, cli *client.Client, workdir string, net
 	internalPort, err := nat.NewPort(proto, internalMasterPort)
 	if err != nil {
 		return "", nil, err
+	}
+
+	if masterConfig.Server.CacheDir != "" {
+		extraMount[master.ServerCacheDir] = masterConfig.Server.CacheDir
 	}
 
 	user, err := user.Current()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type ServerConfig struct {
 	DBAddress  string
 	DBWorkers  int
 	OutputDir  string
+	CacheDir   string
 	ImageName  string `yaml:"image"`
 	Debug      bool
 	ExtraEnv   map[string]string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,7 +41,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfig([]byte(config))
+	_, err := ReadConfigFromBytes([]byte(config))
 	if err != nil {
 		t.Logf("Broken config %v", err)
 		t.Fail()
@@ -84,7 +84,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfig([]byte(config))
+	_, err := ReadConfigFromBytes([]byte(config))
 	if err == nil || err.Error() != "1. reporter misconfigured Name invalid" {
 		t.Log(err)
 		t.Fail()
@@ -128,7 +128,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfig([]byte(config))
+	_, err := ReadConfigFromBytes([]byte(config))
 	if err == nil || err.Error() != "2. analyzer misconfigured duplicate value of The Testalyzer in Name" {
 		t.Log(err)
 		t.Fail()
@@ -171,7 +171,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfig([]byte(config))
+	_, err := ReadConfigFromBytes([]byte(config))
 	if err == nil || err.Error() != "1. analyzer misconfigured Analyzer invalid" {
 		t.Log(err)
 		t.Fail()
@@ -213,7 +213,7 @@ package:
     - config:
         tester: "Endocode"
 `
-	_, err := ReadConfig([]byte(config))
+	_, err := ReadConfigFromBytes([]byte(config))
 	if err == nil || err.Error() != "1. reporter misconfigured Name invalid" {
 		t.Log(err)
 		t.Fail()
@@ -257,7 +257,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfig([]byte(config))
+	_, err := ReadConfigFromBytes([]byte(config))
 	if err == nil || err.Error() != "2. analyzer misconfigured duplicate value of The_Testalyzer in PosixName" {
 		t.Log(err)
 		t.Fail()
@@ -292,7 +292,7 @@ package:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfig([]byte(config))
+	_, err := ReadConfigFromBytes([]byte(config))
 	if err == nil || err.Error() != "Invalid RPC address" {
 		t.Log(err)
 		t.Fail()


### PR DESCRIPTION
Implement using multiple configuration files to use the host specific configuration /etc/qmstr/qmstr.yaml .
This makes setting a cachedir (host specific) possible.

closes https://github.com/QMSTR/qmstr-all/issues/98