### PR TITLE
Use relative paths

### DIFF
--- a/cmd/modules/analyzers/pkg-analyzer/main.go
+++ b/cmd/modules/analyzers/pkg-analyzer/main.go
@@ -78,7 +78,6 @@ func (pkganalyzer *PkgAnalyzer) Analyze(controlService service.ControlServiceCli
 			for _, target := range pkganalyzer.targetsSlice {
 				re := regexp.MustCompile(filepath.Join(pkganalyzer.targetsDir, target))
 				if re.MatchString(fileNode.Path) {
-					log.Printf("Adding node %v to package targets.", fileNode.Path)
 					FileNodeMsgs = append(FileNodeMsgs, &service.FileNodeMessage{Token: token, Uid: pkgNode.Uid, Filenode: fileNode})
 					break
 				}

--- a/cmd/modules/analyzers/test-analyzer/main.go
+++ b/cmd/modules/analyzers/test-analyzer/main.go
@@ -20,10 +20,11 @@ const (
 )
 
 var (
-	testnode     *service.FileNode
-	pkgNode      *service.PackageNode
-	tests        []string
-	testfunction func(*testing.T)
+	testnode        *service.FileNode
+	pkgNode         *service.PackageNode
+	tests           []string
+	testfunction    func(*testing.T)
+	expectedTargets []string
 )
 
 type TestAnalyzer struct{}
@@ -85,9 +86,11 @@ func (testanalyzer *TestAnalyzer) Analyze(controlService service.ControlServiceC
 		if test == "TestPackageNode" {
 			testfunction = TestPackageNode
 		} else if test == "TestCalcBuildGraph" {
-			testfunction = TestCalcBuildGraph
+			expectedTargets = []string{"Calculator/calc", "Calculator/libcalc.so"}
+			testfunction = TestBuildGraph
 		} else if test == "TestCurlBuildGraph" {
-			testfunction = TestCurlBuildGraph
+			expectedTargets = []string{"curl/build/src/curl", "curl/build/lib/libcurl.so"}
+			testfunction = TestBuildGraph
 		} else {
 			log.Printf("Unknown test. Please check the test name provided in the configuration.")
 			os.Exit(master.ReturnAnalyzerFailed)
@@ -153,8 +156,7 @@ func TestPackageNode(t *testing.T) {
 	}
 }
 
-func TestCurlBuildGraph(t *testing.T) {
-	expectedTargets := []string{"/buildroot/curl/build/src/curl", "/buildroot/curl/build/lib/libcurl.so"}
+func TestBuildGraph(t *testing.T) {
 	if len(pkgNode.Targets) < 2 {
 		t.Logf("Package node '%v' is not connected to all the configured linked targets", pkgNode.Name)
 		t.Fail()
@@ -166,16 +168,5 @@ func TestCurlBuildGraph(t *testing.T) {
 				t.Fail()
 			}
 		}
-	}
-}
-
-func TestCalcBuildGraph(t *testing.T) {
-	expectedTarget := "/buildroot/Calculator/calc"
-	if len(pkgNode.Targets) < 1 {
-		t.Logf("Package node '%v' is not connected to any linked targets", pkgNode.Name)
-		t.Fail()
-	} else if pkgNode.Targets[0].Path != expectedTarget {
-		t.Logf("Package node %v is not connected to calc linked target", pkgNode.Name)
-		t.Fail()
 	}
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -81,6 +81,10 @@ func startMaster(cmd *cobra.Command, args []string) {
 		config.BuildConfig = buildConfig
 	}
 
+	if config.Server.BuildPath == "" {
+		config.Server.BuildPath = containerBuildDir
+	}
+
 	configuredImageName := config.Server.ImageName
 	if configuredImageName != "" {
 		Debug.Printf("using configured image %s", configuredImageName)

--- a/pkg/common/fileutil.go
+++ b/pkg/common/fileutil.go
@@ -3,6 +3,9 @@ package common
 import (
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/QMSTR/qmstr/pkg/service"
 )
 
 func BuildCleanPath(base string, subpath string, abs bool) string {
@@ -40,4 +43,16 @@ func exists(file string) bool {
 		return true
 	}
 	return false
+}
+
+func SetRelativePath(node *service.FileNode, buildPath string, pathSub []*service.PathSubstitution) error {
+	for _, substitution := range pathSub {
+		node.Path = strings.Replace(node.Path, substitution.Old, substitution.New, 1)
+	}
+	relPath, err := filepath.Rel(buildPath, node.Path)
+	if err != nil {
+		return err
+	}
+	node.Path = relPath
+	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type ServerConfig struct {
 	Debug      bool
 	ExtraEnv   map[string]string
 	ExtraMount map[string]string
+	BuildPath  string
 	PathSub    []*service.PathSubstitution
 }
 

--- a/pkg/gccbuilder/gcc-builder.go
+++ b/pkg/gccbuilder/gcc-builder.go
@@ -137,7 +137,7 @@ func (g *GccBuilder) Analyze(commandline []string) (*pb.BuildMessage, error) {
 			g.Logger.Fatalf("Failed to collect dependencies: %v", err)
 		}
 		for _, actualLib := range actualLibs {
-			linkLib := builder.NewFileNode(actualLib, linkedTrg)
+			linkLib := builder.NewFileNode(common.BuildCleanPath(g.WorkDir, actualLib, false), linkedTrg)
 			dependencies = append(dependencies, linkLib)
 		}
 		linkedTarget.DerivedFrom = dependencies

--- a/pkg/master/analyze.go
+++ b/pkg/master/analyze.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/QMSTR/qmstr/pkg/common"
 	"github.com/QMSTR/qmstr/pkg/config"
 	"github.com/QMSTR/qmstr/pkg/database"
 	"github.com/QMSTR/qmstr/pkg/service"
@@ -139,12 +140,11 @@ func (phase *serverPhaseAnalysis) SendFileNodes(stream service.AnalysisService_S
 		}
 		fileNode := fileNodeReq.Filenode
 		fileNode.NodeType = service.NodeTypeFileNode
-		relPath, err := filepath.Rel(phase.masterConfig.Server.BuildPath, fileNode.Path)
+		err = common.SetRelativePath(fileNode, phase.masterConfig.Server.BuildPath, nil)
 		if err != nil {
 			return err
 		}
 
-		fileNode.Path = relPath
 		log.Printf("Adding file node %v to package targets.", fileNode.Path)
 		err = phase.db.AddFileNodes(fileNodeReq.Uid, fileNode)
 		if err != nil {

--- a/pkg/master/build.go
+++ b/pkg/master/build.go
@@ -2,6 +2,8 @@ package master
 
 import (
 	"log"
+	"path/filepath"
+	"strings"
 
 	"github.com/QMSTR/qmstr/pkg/config"
 	"github.com/QMSTR/qmstr/pkg/database"
@@ -33,6 +35,14 @@ func (phase *serverPhaseBuild) GetPhaseID() int32 {
 
 func (phase *serverPhaseBuild) Build(in *service.BuildMessage) (*service.BuildResponse, error) {
 	for _, node := range in.FileNodes {
+		for _, substitution := range phase.masterConfig.Server.PathSub {
+			node.Path = strings.Replace(node.Path, substitution.Old, substitution.New, 1)
+		}
+		relPath, err := filepath.Rel(phase.masterConfig.Server.BuildPath, node.Path)
+		if err != nil {
+			return nil, err
+		}
+		node.Path = relPath
 		log.Printf("Adding file node %s", node.Path)
 		phase.db.AddFileNode(node)
 	}


### PR DESCRIPTION
Use relative paths to workdir/builddir instead of the absolute path.
No need to store the absolute path.
Get rid of the ugly /buildroot from the path.

closes QMSTR/qmstr-all/issues/91