### PR TITLE
Combine RUN apt-get update with install

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -9,8 +9,8 @@ FROM ubuntu:18.04 as runtimebase
 LABEL org.qmstr.image runtime
 
 # install runtime deps
-RUN apt-get update && \
-    apt-get install -y software-properties-common curl autoconf git libgit2-dev libio-captureoutput-perl python python-pip python3-distutils protobuf-compiler && \
+RUN apt-get update && apt-get install -y \
+    software-properties-common curl autoconf git libgit2-dev libio-captureoutput-perl python python-pip python3-distutils protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
 ARG HUGO_VERSION
@@ -48,12 +48,12 @@ LABEL org.qmstr.image builder
 ENV GOPATH /go
 ENV PATH ${GOPATH}/bin:$PATH
 # install golang
-RUN apt-get update && \
-    apt-get install -y curl golang autoconf git libgit2-dev libio-captureoutput-perl python-dev python-virtualenv protobuf-compiler
+RUN apt-get update && apt-get install -y \
+    curl golang autoconf git libgit2-dev libio-captureoutput-perl python-dev python-virtualenv protobuf-compiler
 
 # install build deps
-RUN apt-get update && \
-    apt-get install -y git protobuf-compiler python-virtualenv python-dev && \
+RUN apt-get update && apt-get install -y \
+    git protobuf-compiler python-virtualenv python-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # install golang tools
@@ -117,8 +117,7 @@ ENTRYPOINT [ "/docker-entrypoint.sh" ]
 # debug stage for container running ratel
 FROM ubuntu:18.04 as web
 
-RUN apt-get update
-RUN apt-get install -y socat
+RUN apt-get update && apt-get install -y socat
 COPY --from=runtime /usr/local/bin/dgraph-ratel /usr/local/bin/dgraph-ratel
 ADD ci/ratel-entrypoint.sh /entrypoint.sh
 
@@ -137,8 +136,8 @@ ENV GOPATH /go
 ENV PATH ${GOPATH}/bin:$PATH
 
 # install golang
-RUN apt-get update && \
-    apt-get install -y curl golang autoconf git libio-captureoutput-perl python-dev python-virtualenv protobuf-compiler
+RUN apt-get update && apt-get install -y \
+    curl golang autoconf git libio-captureoutput-perl python-dev python-virtualenv protobuf-compiler
 
 EXPOSE 2345
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,6 +8,8 @@ FROM ubuntu:18.04 as runtimebase
 
 LABEL org.qmstr.image runtime
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 # install runtime deps
 RUN apt-get update && apt-get install -y \
     software-properties-common curl autoconf git libgit2-dev libio-captureoutput-perl python python-pip python3-distutils protobuf-compiler && \
@@ -47,6 +49,8 @@ FROM ubuntu:18.04 as builder
 LABEL org.qmstr.image builder
 ENV GOPATH /go
 ENV PATH ${GOPATH}/bin:$PATH
+ENV DEBIAN_FRONTEND=noninteractive
+
 # install golang
 RUN apt-get update && apt-get install -y \
     curl golang autoconf git libgit2-dev libio-captureoutput-perl python-dev python-virtualenv protobuf-compiler
@@ -116,6 +120,8 @@ ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
 # debug stage for container running ratel
 FROM ubuntu:18.04 as web
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y socat
 COPY --from=runtime /usr/local/bin/dgraph-ratel /usr/local/bin/dgraph-ratel


### PR DESCRIPTION
Use RUN apt-get update with apt-get install in the same RUN to avoid cashing issues and subsequently avoid apt-get install to fail.