### PR TITLE
Fix check points for file exists

### DIFF
--- a/cmd/modules/analyzers/missing_pieces-analyzer/main.go
+++ b/cmd/modules/analyzers/missing_pieces-analyzer/main.go
@@ -27,7 +27,7 @@ func main() {
 
 func (mpanalyzer *MissingPiecesAnalyzer) Configure(configMap map[string]string) error {
 	if inputfile, ok := configMap["inputfile"]; ok {
-		if _, err := os.Stat(inputfile); os.IsNotExist(err) {
+		if _, err := os.Stat(inputfile); err != nil {
 			return fmt.Errorf("File %s not found", inputfile)
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,7 +69,7 @@ func ReadConfigFromFiles(configfiles ...string) (*MasterConfig, error) {
 	fileNotExistCount := 0
 	config := getDefaultConfig()
 	for _, configfile := range configfiles {
-		if _, err := os.Stat(configfile); os.IsNotExist(err) {
+		if _, err := os.Stat(configfile); err != nil {
 			log.Printf("File %s not found", configfile)
 			fileNotExistCount++
 			continue

--- a/pkg/master/init.go
+++ b/pkg/master/init.go
@@ -54,7 +54,10 @@ func (phase *serverPhaseInit) Activate() error {
 
 func snapshotAvailable() bool {
 	_, err := os.Stat(common.ContainerGraphImportPath)
-	return !os.IsNotExist(err)
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 func importSnapshot() error {


### PR DESCRIPTION
There are way more errors than just ErrNotExist.
We should catch all the errors cause we need to be sure that we have access to the files.