### PR TITLE
Refactor GetFileNodesByFileNode to support other queries apart from fileType

### DIFF
--- a/pkg/master/analyze.go
+++ b/pkg/master/analyze.go
@@ -186,7 +186,7 @@ func (phase *serverPhaseAnalysis) GetFileNode(in *service.FileNode, stream servi
 	if err != nil {
 		return err
 	}
-	nodeFiles, err := db.GetFileNodesByFileNode(in)
+	nodeFiles, err := db.GetFileNodesByFileNode(in, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/master/common.go
+++ b/pkg/master/common.go
@@ -112,7 +112,7 @@ func (gsp *genericServerPhase) GetFileNode(in *service.FileNode, stream service.
 	if err != nil {
 		return err
 	}
-	nodeFiles, err := db.GetFileNodesByFileNode(in)
+	nodeFiles, err := db.GetFileNodesByFileNode(in, true)
 
 	for _, nodeFile := range nodeFiles {
 		stream.Send(nodeFile)


### PR DESCRIPTION
GetFileNodesByFileNode used to query only fileTypes. 
Now it is more generic and it can support other queries.