### PR TITLE
Implement qmstrctl describe command 

### DIFF
--- a/pkg/cli/describe.go
+++ b/pkg/cli/describe.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/QMSTR/qmstr/pkg/qmstr/service"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+)
+
+var (
+	packageName, target string
+)
+
+var describeCmd = &cobra.Command{
+	Use:   "describe [type_of_node:node]",
+	Short: "Print description of the node",
+	Long: `Print description of the node and traverse the tree 
+to print the description of the nodes connected to it.
+
+input: [type_of_node:node], where type_of_node can be:
+	- package
+	- target 
+	- info
+and node, can be:
+	- node name
+	- node path 
+	- node type`,
+	Run: func(cmd *cobra.Command, args []string) {
+		setUpServer()
+		if err := describeNode(args); err != nil {
+			Log.Fatalf("Describe failed: %v", err)
+		}
+		tearDownServer()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(describeCmd)
+}
+
+func describeNode(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("Please provide the node you want to get description for: [type_of_node:node]")
+	}
+
+	input := strings.Split(args[0], ":")
+	if len(input) != 2 {
+		return fmt.Errorf("Please provide input in the format: [type_of_node:node]")
+	}
+	nodeType := input[0]
+	node := input[1]
+
+	queryNode := &service.FileNode{}
+
+	switch nodeType {
+	case "package":
+		//query package name
+		fmt.Printf("Type %s is not yet implemented", nodeType)
+	case "target":
+		path := strings.Contains(node, "/")
+		if path {
+			queryNode = &service.FileNode{Path: node}
+		} else {
+			queryNode = &service.FileNode{Name: node}
+		}
+
+		stream, err := controlServiceClient.GetFileNode(context.Background(), queryNode)
+		if err != nil {
+			log.Printf("Could not get file node %v", err)
+			return err
+		}
+
+		for {
+			fileNode, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+
+			json, err := json.MarshalIndent(fileNode, "", "   ")
+			fmt.Printf("%v \n", string(json))
+		}
+	case "info":
+		//TODO: query for infonode
+		fmt.Printf("Type %s is not yet implemented", nodeType)
+	}
+
+	return nil
+}

--- a/pkg/cli/describe.go
+++ b/pkg/cli/describe.go
@@ -78,8 +78,14 @@ func describeNode(args []string) error {
 
 		for {
 			fileNode, err := stream.Recv()
-			if err == io.EOF {
-				break
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				if err.Error() == "rpc error: code = Unknown desc = No file node found" {
+					return fmt.Errorf("No file node %s found in the database", node)
+				}
+				return err
 			}
 
 			json, err := json.MarshalIndent(fileNode, "", "   ")

--- a/pkg/cli/describe.go
+++ b/pkg/cli/describe.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	packageName, target string
+	less                bool
 )
 
 var describeCmd = &cobra.Command{
@@ -41,6 +42,7 @@ and node, can be:
 
 func init() {
 	rootCmd.AddCommand(describeCmd)
+	describeCmd.Flags().BoolVar(&less, "less", false, "show less information-info nodes are not traversed")
 }
 
 func describeNode(args []string) error {
@@ -55,21 +57,20 @@ func describeNode(args []string) error {
 	nodeType := input[0]
 	node := input[1]
 
-	queryNode := &service.FileNode{}
-
 	switch nodeType {
 	case "package":
 		//query package name
 		fmt.Printf("Type %s is not yet implemented", nodeType)
 	case "target":
+		queryNode := &service.FileNode{}
 		path := strings.Contains(node, "/")
 		if path {
 			queryNode = &service.FileNode{Path: node}
 		} else {
 			queryNode = &service.FileNode{Name: node}
 		}
-
-		stream, err := controlServiceClient.GetFileNodeDescription(context.Background(), queryNode)
+		descriptionRequest := &service.FileDescriptionRequest{File: queryNode, LessInfo: less}
+		stream, err := controlServiceClient.GetFileNodeDescription(context.Background(), descriptionRequest)
 		if err != nil {
 			log.Printf("Could not get file node %v", err)
 			return err

--- a/pkg/cli/describe.go
+++ b/pkg/cli/describe.go
@@ -60,7 +60,15 @@ func describeNode(args []string) error {
 	switch nodeType {
 	case "package":
 		//query package name
-		fmt.Printf("Type %s is not yet implemented", nodeType)
+		pkgNode, err := controlServiceClient.GetPackageNode(context.Background(), &service.PackageRequest{Name: node, LessInfo: less})
+		if err != nil {
+			return err
+		}
+
+		err = printNode(pkgNode)
+		if err != nil {
+			return err
+		}
 	case "target":
 		queryNode := &service.FileNode{}
 		path := strings.Contains(node, "/")
@@ -88,13 +96,24 @@ func describeNode(args []string) error {
 				return err
 			}
 
-			json, err := json.MarshalIndent(fileNode, "", "   ")
-			fmt.Printf("%v \n", string(json))
+			err = printNode(fileNode)
+			if err != nil {
+				return err
+			}
 		}
 	case "info":
 		//TODO: query for infonode
 		fmt.Printf("Type %s is not yet implemented", nodeType)
 	}
 
+	return nil
+}
+
+func printNode(node interface{}) error {
+	json, err := json.MarshalIndent(node, "", "   ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%v \n", string(json))
 	return nil
 }

--- a/pkg/cli/describe.go
+++ b/pkg/cli/describe.go
@@ -69,7 +69,7 @@ func describeNode(args []string) error {
 			queryNode = &service.FileNode{Name: node}
 		}
 
-		stream, err := controlServiceClient.GetFileNode(context.Background(), queryNode)
+		stream, err := controlServiceClient.GetFileNodeDescription(context.Background(), queryNode)
 		if err != nil {
 			log.Printf("Could not get file node %v", err)
 			return err

--- a/pkg/database/dgraph.go
+++ b/pkg/database/dgraph.go
@@ -222,7 +222,7 @@ func (db *DataBase) insertPkgNode(node *service.PackageNode) {
 
 	// we are ready to insert the node
 	db.insertMutex.Lock()
-	packageNode, err := db.GetPackageNode(node.Session)
+	packageNode, err := db.GetPackageNode(node.Session, false, false)
 	if err == nil {
 		node.Uid = packageNode.Uid
 		node.Targets = append(packageNode.Targets, node.Targets...)

--- a/pkg/database/fileNode.go
+++ b/pkg/database/fileNode.go
@@ -177,7 +177,13 @@ func (db *DataBase) GetFileNodesByFileNode(filenode *service.FileNode, recursive
 		return nil, err
 	}
 
-	return ret["getFileNodeByFileNode"], nil
+	fileNodes := ret["getFileNodeByFileNode"]
+
+	if len(fileNodes) < 1 {
+		return nil, errors.New("No file node found")
+	}
+
+	return fileNodes, nil
 }
 
 func (db *DataBase) GetFileNodeHashByPath(path string) (string, error) {

--- a/pkg/database/fileNode.go
+++ b/pkg/database/fileNode.go
@@ -93,16 +93,30 @@ func (db *DataBase) GetFileNodeUid(hash string) (string, error) {
 // with this filetype.
 // You can query for just one attribute. For instance, if you set filetype and hash, only the
 // hash will be used in the query.
-func (db *DataBase) GetFileNodesByFileNode(filenode *service.FileNode, recursive bool, describe bool) ([]*service.FileNode, error) {
+func (db *DataBase) GetFileNodesByFileNode(filenode *service.FileNode, recursive bool, describe bool, lessInfo bool) ([]*service.FileNode, error) {
 	var ret map[string][]*service.FileNode
 	var q string
 	if describe {
-		q = `query FileNodeByFileNode($Filter: string, $TypeFilter: int){
-				getFileNodeByFileNode(func: has(fileNodeType)) {{.Query}} {{.Recurse}}{
-				  name
-				  path
-				  derivedFrom
-				}}`
+		if lessInfo {
+			q = `query FileNodeByFileNode($Filter: string, $TypeFilter: int){
+			getFileNodeByFileNode(func: has(fileNodeType)) {{.Query}} {{.Recurse}}{
+			  name
+			  path
+			  derivedFrom
+			}}`
+		} else {
+			q = `query FileNodeByFileNode($Filter: string, $TypeFilter: int){
+					getFileNodeByFileNode(func: has(fileNodeType)) {{.Query}} {{.Recurse}}{
+					  name
+					  path
+					  derivedFrom
+					  additionalInfo
+					  type
+					  analyzer
+					  dataNodes
+					  data
+					}}`
+		}
 	} else {
 		q = `query FileNodeByFileNode($Filter: string, $TypeFilter: int){
 				getFileNodeByFileNode(func: has(fileNodeType)) {{.Query}} {{.Recurse}}{

--- a/pkg/master/analyze.go
+++ b/pkg/master/analyze.go
@@ -186,7 +186,7 @@ func (phase *serverPhaseAnalysis) GetFileNode(in *service.FileNode, stream servi
 	if err != nil {
 		return err
 	}
-	nodeFiles, err := db.GetFileNodesByFileNode(in, true)
+	nodeFiles, err := db.GetFileNodesByFileNode(in, true, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/master/analyze.go
+++ b/pkg/master/analyze.go
@@ -186,7 +186,7 @@ func (phase *serverPhaseAnalysis) GetFileNode(in *service.FileNode, stream servi
 	if err != nil {
 		return err
 	}
-	nodeFiles, err := db.GetFileNodesByFileNode(in, true, false)
+	nodeFiles, err := db.GetFileNodesByFileNode(in, true, false, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/master/common.go
+++ b/pkg/master/common.go
@@ -112,7 +112,7 @@ func (gsp *genericServerPhase) GetFileNode(in *service.FileNode, stream service.
 	if err != nil {
 		return err
 	}
-	nodeFiles, err := db.GetFileNodesByFileNode(in, true)
+	nodeFiles, err := db.GetFileNodesByFileNode(in, true, false)
 
 	for _, nodeFile := range nodeFiles {
 		stream.Send(nodeFile)

--- a/pkg/master/common.go
+++ b/pkg/master/common.go
@@ -112,7 +112,7 @@ func (gsp *genericServerPhase) GetFileNode(in *service.FileNode, stream service.
 	if err != nil {
 		return err
 	}
-	nodeFiles, err := db.GetFileNodesByFileNode(in, true, false)
+	nodeFiles, err := db.GetFileNodesByFileNode(in, true, false, false)
 
 	for _, nodeFile := range nodeFiles {
 		stream.Send(nodeFile)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -119,6 +119,7 @@ func (s *server) GetFileNodeDescription(in *service.FileDescriptionRequest, stre
 	for _, nodeFile := range nodeFiles {
 		stream.Send(nodeFile)
 	}
+
 	return nil
 }
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -106,12 +106,12 @@ func (s *server) GetFileNode(in *service.FileNode, stream service.ControlService
 	return s.currentPhase.GetFileNode(in, stream)
 }
 
-func (s *server) GetFileNodeDescription(in *service.FileNode, stream service.ControlService_GetFileNodeDescriptionServer) error {
+func (s *server) GetFileNodeDescription(in *service.FileDescriptionRequest, stream service.ControlService_GetFileNodeDescriptionServer) error {
 	db, err := s.currentPhase.getDataBase()
 	if err != nil {
 		return err
 	}
-	nodeFiles, err := db.GetFileNodesByFileNode(in, true, true)
+	nodeFiles, err := db.GetFileNodesByFileNode(in.File, true, true, in.LessInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -106,6 +106,22 @@ func (s *server) GetFileNode(in *service.FileNode, stream service.ControlService
 	return s.currentPhase.GetFileNode(in, stream)
 }
 
+func (s *server) GetFileNodeDescription(in *service.FileNode, stream service.ControlService_GetFileNodeDescriptionServer) error {
+	db, err := s.currentPhase.getDataBase()
+	if err != nil {
+		return err
+	}
+	nodeFiles, err := db.GetFileNodesByFileNode(in, true, true)
+	if err != nil {
+		return err
+	}
+
+	for _, nodeFile := range nodeFiles {
+		stream.Send(nodeFile)
+	}
+	return nil
+}
+
 func (s *server) GetInfoData(ctx context.Context, in *service.InfoDataRequest) (*service.InfoDataResponse, error) {
 	return s.currentPhase.GetInfoData(in)
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -78,7 +78,14 @@ func (s *server) GetPackageNode(ctx context.Context, in *service.PackageRequest)
 	if err != nil {
 		return nil, err
 	}
-	node, err := db.GetPackageNode(in.Session)
+
+	node := &service.PackageNode{}
+	if in.Session != "" {
+		node, err = db.GetPackageNode(in.Session, false, in.LessInfo)
+	}
+	if in.Name != "" {
+		node, err = db.GetPackageNode(in.Name, true, in.LessInfo)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +97,7 @@ func (s *server) SendBuildError(ctx context.Context, in *service.InfoNode) (*ser
 	if err != nil {
 		return nil, err
 	}
-	node, err := db.GetPackageNode(s.currentPhase.getSession())
+	node, err := db.GetPackageNode(s.currentPhase.getSession(), false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/master/report.go
+++ b/pkg/master/report.go
@@ -76,7 +76,7 @@ func (phase *serverPhaseReport) GetBOM(in *service.BOMRequest) (*service.BOM, er
 	if err != nil {
 		return nil, err
 	}
-	pkgNode, err := db.GetPackageNode(in.Session)
+	pkgNode, err := db.GetPackageNode(in.Session, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/proto/qmstr/service/controlservice.proto
+++ b/proto/qmstr/service/controlservice.proto
@@ -31,6 +31,8 @@ message SwitchPhaseResponse {
 
 message PackageRequest {
   string session = 1;
+  string name = 2;
+  bool lessInfo = 3;
 }
 
 message StatusMessage {

--- a/proto/qmstr/service/controlservice.proto
+++ b/proto/qmstr/service/controlservice.proto
@@ -57,6 +57,11 @@ message ExportResponse {
   bool success = 1;
 }
 
+message FileDescriptionRequest {
+  FileNode file = 1;
+  bool lessInfo = 2;
+}
+
 service ControlService {
   rpc Log(LogMessage) returns (LogResponse) {}
   rpc Quit(QuitMessage) returns (QuitResponse) {}
@@ -66,5 +71,5 @@ service ControlService {
   rpc Status(StatusMessage) returns (StatusResponse) {}
   rpc SubscribeEvents(EventMessage) returns (stream Event) {}
   rpc ExportSnapshot(ExportRequest) returns (ExportResponse) {}
-  rpc GetFileNodeDescription(FileNode) returns (stream FileNode) {}
+  rpc GetFileNodeDescription(FileDescriptionRequest) returns (stream FileNode) {}
 }

--- a/proto/qmstr/service/controlservice.proto
+++ b/proto/qmstr/service/controlservice.proto
@@ -66,4 +66,5 @@ service ControlService {
   rpc Status(StatusMessage) returns (StatusResponse) {}
   rpc SubscribeEvents(EventMessage) returns (stream Event) {}
   rpc ExportSnapshot(ExportRequest) returns (ExportResponse) {}
+  rpc GetFileNodeDescription(FileNode) returns (stream FileNode) {}
 }


### PR DESCRIPTION
Describe command prints a description of the node in call.
It follows the generic syntax: package:Calculator or target:Calculator/calc, to reference nodes from the command line.
To get less information, which means to get only file nodes, info nodes are omitted, include the --less flag.
Describe cmd is not implemented to reference info nodes from the command line yet.


Closes https://github.com/QMSTR/qmstr-all/issues/169