### PR TITLE
Add sourceURL field in PackageInformation

### DIFF
--- a/proto/qmstr/service/bom.proto
+++ b/proto/qmstr/service/bom.proto
@@ -10,6 +10,7 @@ message PackageInformation {
 	string ocFossLiaison = 4;
     string ocComplianceContact = 5;
     string licenseDeclared = 6;
+    string sourceURL = 8;
 }
 
 message Person {


### PR DESCRIPTION
This field is to be set by the user (or tool?) in the "metadata" section
of the QMSTR yaml config file and it should point to the source of the
package being analyzed

For example:
* http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
* git://git.myproject.org/MyProject