### PR TITLE
Fix html reporter commit message

### DIFF
--- a/pkg/reporting/revision_data.go
+++ b/pkg/reporting/revision_data.go
@@ -28,6 +28,7 @@ func CommitMessageSummary(message string) string {
 		summary = fmt.Sprintf("%s...", summary[:47])
 	}
 	// escape double quotes
+	summary = strings.Replace(summary, `\`, `\\`, -1)
 	summary = strings.Replace(summary, `"`, `\"`, -1)
 	return summary
 }


### PR DESCRIPTION
If commit message includes \ it will break the parser.
The fix for that would be to replace it with \\\\