### PR TITLE
Increase VMs memory for scancode

### DIFF
--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -8,6 +8,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "ci/vagrant-bootstrap.sh"
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 2048
+    v.memory = 4096
   end
 end


### PR DESCRIPTION
Scancode eats RAM so double available RAM to 4GB.