### PR TITLE
Include TrustLevel in InfoNode query

### DIFF
--- a/lib/go-qmstr/database/dgraph.go
+++ b/lib/go-qmstr/database/dgraph.go
@@ -32,6 +32,7 @@ name:string @index(hash) .
 dataNodes:uid @reverse .
 data:string @index(hash) .
 projectNodeType:string @index(hash) .
+trustLevel:string @index(hash) .
 packageNodeType:string @index(hash) .
 fileNodeType:string @index(hash) .
 infoNodeType:string @index(hash) .

--- a/lib/go-qmstr/database/dgraph_test.go
+++ b/lib/go-qmstr/database/dgraph_test.go
@@ -38,6 +38,7 @@ hash:string @index(exact) .
 name:string @index(hash) .
 path:string @index(hash,trigram) .
 type:string @index(hash) .
+trustLevel:string @index(hash) .
 fileType:int @index(int) .
 phase:int .
 dataNodes:uid @reverse .

--- a/lib/go-qmstr/database/infoNode.go
+++ b/lib/go-qmstr/database/infoNode.go
@@ -73,7 +73,7 @@ func (db *DataBase) AddInfoNodes(nodeID string, infonodes ...*service.InfoNode) 
 }
 
 // GetInfoDataByTrustLevel returns infonodes containing the datanodes detected from the most trusted analyzer
-func (db *DataBase) GetInfoDataByTrustLevel(fileID string, infotype string) ([]*service.InfoNode, error) {
+func (db *DataBase) GetInfoDataByTrustLevel(fileID string, infotype string) ([]string, error) {
 	var ret map[string][]*service.InfoNode
 
 	const q = `query InfoData($ID: string, $Itype: string){
@@ -126,14 +126,16 @@ func (db *DataBase) GetInfoDataByTrustLevel(fileID string, infotype string) ([]*
 		return nil, nil
 	}
 
-	realData := []*service.InfoNode{}
+	realData := []string{}
 
 	for _, info := range infoData {
 		// infoData contains all the infodata attached to the filenode (with the declared info type)
 		// but the query returns only the most trusted analyzer connected to the infonodes
 		// So only info nodes with an analyzer attached are the trustworthy data
-		if len(info.Analyzer) != 0 {
-			realData = append(realData, info)
+		if len(info.Analyzer) > 0 {
+			for _, data := range info.DataNodes {
+				realData = append(realData, data.Data)
+			}
 		}
 	}
 

--- a/lib/go-qmstr/database/infoNode.go
+++ b/lib/go-qmstr/database/infoNode.go
@@ -73,12 +73,13 @@ func (db *DataBase) AddInfoNodes(nodeID string, infonodes ...*service.InfoNode) 
 }
 
 // GetInfoDataByTrustLevel returns infonodes containing the datanodes detected from the most trusted analyzer
-func (db *DataBase) GetInfoDataByTrustLevel(fileID string, infotype string) ([]string, error) {
+func (db *DataBase) GetInfoDataByTrustLevel(fileID string, infotype string, datatype string) ([]string, error) {
 	var ret map[string][]*service.InfoNode
 
-	const q = `query InfoData($ID: string, $Itype: string){
+	const q = `query InfoData($ID: string, $Itype: string, $Dtype: string){
 		var(func: uid($ID)) @recurse(loop: false) {
 			name
+			derivedFrom
 			T as additionalInfo @filter(eq(type, $Itype))
 		}
 		var(func: uid(T)){
@@ -95,8 +96,7 @@ func (db *DataBase) GetInfoDataByTrustLevel(fileID string, infotype string) ([]s
 			name
 			type
 			analyzer @filter(eq(trustLevel, val(A)))
-			trustLevel
-			dataNodes
+			dataNodes @filter(eq(type, $Dtype))
 			data
 		}
 	  }`
@@ -106,10 +106,11 @@ func (db *DataBase) GetInfoDataByTrustLevel(fileID string, infotype string) ([]s
 	type QueryParams struct {
 		ID    string
 		Itype string
+		Dtype string
 	}
 	qp := QueryParams{}
 
-	vars := map[string]string{"$ID": fileID, "$Itype": infotype}
+	vars := map[string]string{"$ID": fileID, "$Itype": infotype, "$Dtype": datatype}
 
 	var b bytes.Buffer
 	err = queryTmpl.Execute(&b, qp)

--- a/lib/go-qmstr/docker/client.go
+++ b/lib/go-qmstr/docker/client.go
@@ -37,16 +37,13 @@ func RunClientContainer(ctx context.Context, cli *client.Client, clientConfig *C
 		NetworkMode: container.NetworkMode(fmt.Sprintf("container:%s", clientConfig.MasterContainerID)),
 	}
 
-	containerCmd := []string{"qmstr"}
-	containerCmd = append(containerCmd, append([]string{"--"}, clientConfig.Cmd...)...)
-
 	clientConfig.Env = append(
 		[]string{fmt.Sprintf("QMSTR_MASTER=%s:%d", clientConfig.MasterContainerID[:12], clientConfig.QmstrInternalPort)},
 		clientConfig.Env...)
 
 	containerConf := &container.Config{
 		Image: clientConfig.Image,
-		Cmd:   containerCmd,
+		Cmd:   clientConfig.Cmd,
 		Tty:   true,
 		Env:   clientConfig.Env,
 	}

--- a/lib/go-qmstr/master/report.go
+++ b/lib/go-qmstr/master/report.go
@@ -83,7 +83,7 @@ func (phase *serverPhaseReport) GetInfoData(in *service.InfoDataRequest) (*servi
 			return nil, err
 		}
 	} else {
-		infos, err = db.GetInfoDataByTrustLevel(in.RootID, in.Infotype)
+		infos, err = db.GetInfoDataByTrustLevel(in.RootID, in.Infotype, in.Datatype)
 	}
 	if err != nil {
 		return nil, err

--- a/lib/go-qmstr/master/report.go
+++ b/lib/go-qmstr/master/report.go
@@ -77,28 +77,16 @@ func (phase *serverPhaseReport) GetInfoData(in *service.InfoDataRequest) (*servi
 	}
 	var infos []string
 
-	if in.Datatype == "" {
+	if in.Infotype == "" {
 		infos, err = db.GetAllInfoData(in.Infotype)
 		if err != nil {
 			return nil, err
 		}
-		return &service.InfoDataResponse{Data: infos}, nil
 	} else {
-		infos, err = db.GetInfoData(in.RootID, in.Infotype, in.Datatype)
+		infos, err = db.GetInfoDataByTrustLevel(in.RootID, in.Infotype)
 	}
 	if err != nil {
 		return nil, err
 	}
-
-	infoSet := map[string]struct{}{}
-	for _, data := range infos {
-		infoSet[data] = struct{}{}
-	}
-
-	uniqInfos := []string{}
-	for key := range infoSet {
-		uniqInfos = append(uniqInfos, key)
-	}
-
-	return &service.InfoDataResponse{Data: uniqInfos}, nil
+	return &service.InfoDataResponse{Data: infos}, nil
 }

--- a/masterserver/Dockerfile
+++ b/masterserver/Dockerfile
@@ -70,6 +70,8 @@ ADD go.mod /qmstr/go.mod
 ADD go.sum /qmstr/go.sum
 ADD versions.env /qmstr/versions.env
 
+ARG GOPROXY
+
 WORKDIR /qmstr
 RUN make gotest
 RUN make install_qmstr_all

--- a/masterserver/Makefile.common
+++ b/masterserver/Makefile.common
@@ -11,6 +11,10 @@ ifdef https_proxy
 	DOCKER_BUILD_ARGS += --build-arg https_proxy=$(https_proxy)
 endif
 
+ifdef GOPROXY
+	DOCKER_BUILD_ARGS += --build-arg GOPROXY=$(GOPROXY)
+endif
+
 # container related
 .PHONY: buildercontainer
 buildercontainer: masterserver/Dockerfile

--- a/modules/analyzers/spdx-analyzer/Makefile.common
+++ b/modules/analyzers/spdx-analyzer/Makefile.common
@@ -4,7 +4,7 @@ SPDX_ANALYZER := spdx-analyzer
 $(SPDX_ANALYZER): $(OUTDIR)analyzers/$(SPDX_ANALYZER)
 
 $(OUTDIR)analyzers/$(SPDX_ANALYZER): venv/bin/pex wheels
-	venv/bin/pex modules/analyzers/$(SPDX_ANALYZER) pyqmstr -e spdxanalyzer.__main__:main --python=venv/bin/python3 --disable-cache -f ./wheels -o $@
+	QMSTR_VERSION=$(QMSTR_VERSION) venv/bin/pex modules/analyzers/$(SPDX_ANALYZER) pyqmstr -e spdxanalyzer.__main__:main --python=venv/bin/python3 --disable-cache -f ./wheels -o $@
 
 PYQMSTR_FILES := $(shell find lib/pyqmstr -name "*.py")
 wheels: venv $(PYQMSTR_FILES)

--- a/modules/analyzers/spdx-analyzer/setup.py
+++ b/modules/analyzers/spdx-analyzer/setup.py
@@ -1,14 +1,15 @@
 from setuptools import setup
+import os
 
 setup(
     name='pyqmstr-spdx-analyzer',
-    version='0.2',
+    version=os.environ["QMSTR_VERSION"],
     description='QMSTR SPDX-Analyzer',
     url='http://qmstr.org',
     license='GPLv3',
 
     packages=['spdxanalyzer'],
-    install_requires=['pyqmstr', 'spdx-tools'],
+    install_requires=["pyqmstr=={}".format(os.environ["QMSTR_VERSION"]), 'spdx-tools'],
     entry_points={
         'console_scripts': [
             'pyqmstr-spdx-analyzer = spdxanalyzer.__main__:main',


### PR DESCRIPTION
closes https://github.com/QMSTR/qmstr-all/issues/97

This PR just creates the query which uses the trust level and returns the most trustworthy data.
We do not query for the data type yet.

Query is not yet used by reporters. We discussed a restructure of the code, to extract bom as a library, and make calls to the db on specific node types (not just query for a package node and traverse on it).
