### PR TITLE
Add node identification parsing mechanism

### DIFF
--- a/pkg/cli/idparsing.go
+++ b/pkg/cli/idparsing.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/QMSTR/go-qmstr/service"
+)
+
+var ErrInvalidNodeIdent = errors.New("Invalid node identifier")
+var ErrInvalidAttribute = errors.New("Invalid attribute")
+var ErrCallByValue = errors.New("you shall not call setFieldValue by value")
+
+func ParseNodeID(nodeid string) (interface{}, error) {
+	nodeIDTokens := strings.Split(nodeid, ":")
+	if len(nodeIDTokens) < 2 {
+		return nil, ErrInvalidNodeIdent
+	}
+	switch nodeIDTokens[0] {
+	case "file":
+		return createResult(&service.FileNode{}, "Path", nodeIDTokens[1:])
+	case "package":
+		return createResult(&service.PackageNode{}, "Name", nodeIDTokens[1:])
+	case "project":
+		return nil, fmt.Errorf("%s not yet supported", nodeIDTokens[0])
+	case "info":
+		return nil, fmt.Errorf("%s not yet supported", nodeIDTokens[0])
+	case "data":
+		return nil, fmt.Errorf("%s not yet supported", nodeIDTokens[0])
+	default:
+		return nil, fmt.Errorf("Unsupported node type %s", nodeIDTokens[0])
+	}
+}
+
+func createResult(node interface{}, defaultAttribute string, args []string) (interface{}, error) {
+	var attr string
+	var value string
+
+	// set default attribute
+	if len(args) < 2 {
+		attr = defaultAttribute
+		value = args[0]
+	} else {
+		attr = strings.Title(args[0])
+		value = args[1]
+	}
+
+	err := setFieldValue(node, attr, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+func setFieldValue(nodeStruct interface{}, attribute string, value string) error {
+	val := reflect.ValueOf(nodeStruct)
+	if val.Kind() != reflect.Ptr {
+		return ErrCallByValue
+	}
+	for val.Kind() == reflect.Ptr || val.Kind() == reflect.Interface {
+		val = val.Elem()
+	}
+
+	if kind := val.Kind(); kind != reflect.Struct {
+		return fmt.Errorf("Not a struct: %v", kind)
+	}
+
+	field := val.FieldByName(attribute)
+	if !field.IsValid() {
+		return ErrInvalidAttribute
+	}
+
+	switch field.Kind() {
+	case reflect.String:
+		// no need to test if string is a string
+		field.SetString(value)
+		return nil
+	case reflect.Int64:
+		i, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return err
+		}
+		field.SetInt(i)
+		return nil
+	case reflect.Bool:
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		field.SetBool(b)
+		return nil
+	default:
+		return fmt.Errorf("Unsupported type %v", field.Kind())
+	}
+}

--- a/pkg/cli/idparsing_test.go
+++ b/pkg/cli/idparsing_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/QMSTR/go-qmstr/service"
+)
+
+func TestInvalidIdentifier(t *testing.T) {
+	_, err := ParseNodeID("invalid")
+	if err != ErrInvalidNodeIdent {
+		t.Fail()
+	}
+}
+
+func TestInvalidNodeType(t *testing.T) {
+	_, err := ParseNodeID("foo:invalid")
+	if err.Error() != "Unsupported node type foo" {
+		t.Fail()
+	}
+}
+
+type Foo struct {
+	Bar     string
+	BarInt  int64
+	BarBool bool
+	BarFoo  *Foo
+}
+
+func TestSetFieldValue(t *testing.T) {
+	foo := Foo{}
+	err := setFieldValue(&foo, "Bar", "foo")
+	if err != nil {
+		t.Fail()
+	}
+	if foo.Bar != "foo" {
+		t.Fail()
+	}
+}
+
+func TestInvalidAttribute(t *testing.T) {
+	err := setFieldValue(&Foo{}, "baz", "foo")
+	if err != ErrInvalidAttribute {
+		t.Fail()
+	}
+}
+
+func TestInt64Attribute(t *testing.T) {
+	foo := Foo{}
+	err := setFieldValue(&foo, "BarInt", "5")
+	if err != nil {
+		t.Fail()
+	}
+	err = setFieldValue(&foo, "BarInt", "test")
+	if err == nil || reflect.TypeOf(err) != reflect.TypeOf((*strconv.NumError)(nil)) {
+		t.Fail()
+	}
+	if foo.BarInt != 5 {
+		t.Fail()
+	}
+}
+
+func TestBoolAttribute(t *testing.T) {
+	foo := Foo{BarBool: false}
+	err := setFieldValue(&foo, "BarBool", "true")
+	if err != nil {
+		t.Fail()
+	}
+	err = setFieldValue(&foo, "BarBool", "test")
+	if err == nil || reflect.TypeOf(err) != reflect.TypeOf((*strconv.NumError)(nil)) {
+		t.Fail()
+	}
+	if !foo.BarBool {
+		t.Fail()
+	}
+}
+
+func TestUnsupportedAttribute(t *testing.T) {
+	foo := Foo{}
+	err := setFieldValue(&foo, "BarFoo", "barfoo")
+	if err == nil || err.Error() != "Unsupported type ptr" {
+		t.Fail()
+	}
+}
+
+func TestNotStruct(t *testing.T) {
+	foo := 5
+	err := setFieldValue(&foo, "BarFoo", "barfoo")
+	if err == nil || err.Error() != "Not a struct: int" {
+		t.Fail()
+	}
+}
+
+func TestCallByValue(t *testing.T) {
+	err := setFieldValue(Foo{}, "BarFoo", "barfoo")
+	if err == nil || err != ErrCallByValue {
+		t.Fail()
+	}
+}
+
+func TestFileNodeParsing(t *testing.T) {
+	fileNode, err := ParseNodeID("file:/dev/null")
+	if err != nil {
+		t.Fail()
+	}
+	if fileNode.(*service.FileNode).Path != "/dev/null" {
+		t.Fail()
+	}
+	fileNode, err = ParseNodeID("file:hash:deadbeef")
+	if err != nil {
+		t.Fail()
+	}
+	if fileNode.(*service.FileNode).Hash != "deadbeef" {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Parse node identifications and return nodes with the desired value set.
This will be used to query the actual node from the database.

For now only file and package nodes are supported.

refs https://github.com/QMSTR/qmstr-all/issues/188