### PR TITLE
A first commit about qmstr commands documentation

### DIFF
--- a/doc/content/qmstr-basics/_index.md
+++ b/doc/content/qmstr-basics/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Qmstr basics"
+date: 2019-02-27T09:48:15Z
+draft: false
+weight: 4
+---
+

--- a/doc/content/qmstr-basics/qmstr-cli/_index.md
+++ b/doc/content/qmstr-basics/qmstr-cli/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Qmstr commands"
+date: 2019-02-27T09:48:15Z
+draft: false
+---
+
+Quartermaster commands are used to interact with the server side, to start a Quartermaster master, switch phases, alter data in the database, quit a Quartermaster master etc.

--- a/doc/content/qmstr-basics/qmstr-cli/database_cmds/_index.md
+++ b/doc/content/qmstr-basics/qmstr-cli/database_cmds/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Database commands"
+date: 2019-02-27T09:48:15Z
+draft: false
+---
+
+Quartermaster uses commands to flexibly modify nodes in the database. For example, if you want manually to add nodes in the database and connect them to other nodes or remove a node or the connection between two nodes, that is possible with the above commands.
+
+All commands use the following generic syntax to reference a node:
+
+    qmstrctl <cmd_to_execute> <type_of_node:attribute:value>
+
+, where `type_of_node` can be either `project`, `package` or `file`,
+
+`attribute` can be `name` or `path` and 
+
+`value`is the value of either the `name` or the `path`.

--- a/doc/content/qmstr-basics/qmstr-cli/database_cmds/connect/_index.md
+++ b/doc/content/qmstr-basics/qmstr-cli/database_cmds/connect/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Connect command"
+date: 2019-02-27T09:48:15Z
+draft: false
+weight: 2
+---
+
+Connect command connects two specified nodes. The command follows the generic syntax of the database commands to reference nodes.
+The form should be:
+
+    qmstrctl connect <type_of_node:attribute:value> <type_of_node:attribute:value>
+
+for example,
+
+    > qmstrctl connect file:name:debug.o file:name:debug.c

--- a/doc/content/qmstr-basics/qmstr-cli/database_cmds/create/_index.md
+++ b/doc/content/qmstr-basics/qmstr-cli/database_cmds/create/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Create command"
+date: 2019-02-27T09:48:15Z
+draft: false
+weight: 1
+---
+
+Create command creates a specific node, either a `project`, a `package` or a `file` node.
+The command follows the generic syntax of the database commands to reference nodes.
+To specify an attribute with a value, include the corresponding flag. 
+
+Type the following to get more information about the command:
+
+    > qmstrctl create file --help
+
+For example:
+
+    > qmstrctl create file --name debug.o
+
+    > qmstrctl create file --name debug.c
+
+

--- a/doc/content/qmstr-basics/qmstr-cli/database_cmds/delete/_index.md
+++ b/doc/content/qmstr-basics/qmstr-cli/database_cmds/delete/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Delete command"
+date: 2019-02-27T09:48:15Z
+draft: false
+weight: 3
+---
+
+Delete command deletes a specified node and follows the generic syntax of the database commands to reference nodes.
+
+    > qmstrctl delete file:name:debug.o


### PR DESCRIPTION
closes https://github.com/QMSTR/qmstr-all/issues/203

The CRUD commands will be seperated, in the documentation, from the rest qmstrctl commands
in the `Database commands` subdirectory.
This is just a first commit, including only a short description of the referenced nodes.