### PR TITLE
Update QMSTR version in the documentation and the code

### DIFF
--- a/doc/content/introduction/getting-started/_index.md
+++ b/doc/content/introduction/getting-started/_index.md
@@ -30,7 +30,7 @@ Verify that the client side tools are available by querying the
 version of the `qmstrctl` tool:
 
     > qmstrctl version
-    This is qmstrctl version 0.2.
+    This is qmstrctl version 0.3.
 
 To check that the master image exists, run
 
@@ -56,7 +56,7 @@ are located in the [tutorial](tutorial/) subdirectory. Let's retrieve
 the JSON-C source code first, in a specific revision that we know
 works with this tutorial:
 
-	> cd doc/tutorial
+	> cd doc/content/introduction/getting-started/tutorial
 	> git clone https://github.com/json-c/json-c.git
 	...
 	> cd json-c

--- a/doc/content/introduction/installation/_index.md
+++ b/doc/content/introduction/installation/_index.md
@@ -118,7 +118,7 @@ If the installation completes successfully, the `qmstrctl` command is
 now available:
 
 	> qmstrctl version
-	This is qmstrctl version 0.2.
+	This is qmstrctl version 0.3.
 
 Only the client side installation and the information about how to
 access the master are required on a system that builds software with

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var major = 0
-var minor = 2
+var minor = 3
 
 // quitCmd represents the quit command
 var versionCmd = &cobra.Command{

--- a/pkg/module/reporter/htmlreporter/htmlreporter.go
+++ b/pkg/module/reporter/htmlreporter/htmlreporter.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/QMSTR/qmstr/pkg/service"
 	"github.com/QMSTR/qmstr/pkg/reporting"
+	"github.com/QMSTR/qmstr/pkg/service"
 	version "github.com/hashicorp/go-version"
 )
 
@@ -24,7 +24,7 @@ const (
 	// ModuleName is used across QMSTR to reference this module
 	ModuleName         = "reporter-html"
 	themeDirectoryName = "theme"
-	cacheVersion       = "0.2"
+	cacheVersion       = "0.3"
 )
 
 // HTMLReporter is the context of the HTML reporter module


### PR DESCRIPTION
The QMSTR version is currently listed in a couple of places. This PR updates it. Long-term, we should have a central way to specify the version and import it across the different toolchains and programming languages used.