### PR TITLE
Enhance command description

### DIFF
--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -28,10 +28,22 @@ func init() {
 }
 
 var connectCmd = &cobra.Command{
-	Use:   "connect",
+	Use:   "connect [type_of_node:attribute:value] [type_of_node:attribute:value]",
 	Short: "Connect nodes with specific edges",
 	Long: `Usage: qmstrctl connect <that> <this>...
-Connect to Node <that> Node(s) <this>. In case of multiple edges for the specified types you can use --<type>To<type>Edge flag to specify the edge you want.`,
+Connect to Node <that> Node(s) <this>. In case of multiple edges for the specified types you can use --<type>To<type>Edge flag to specify the edge you want.
+
+input: [type_of_node:attribute:value]
+
+type_of_node:
+	- package
+	- file
+attribute:
+	- hash
+	- path
+	- name
+	- type
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		setUpControlService()
 		setUpBuildService()

--- a/pkg/cli/describe.go
+++ b/pkg/cli/describe.go
@@ -17,16 +17,18 @@ var describeCmd = &cobra.Command{
 	Long: `Print description of the node and traverse the tree 
 to print the description of the nodes connected to it.
 
-input: [type_of_node:attribute:value], where type_of_node can be:
+input: [type_of_node:attribute:value]
+
+type_of_node:
 	- package
-	- target 
-attribute can be:
-	- name
-	- path 
-	- type
+	- file
+attribute:
 	- hash
-and value, the value of the attribute.
+	- path
+	- name
+	- type
 	`,
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		setUpControlService()
 		if err := describeNode(args); err != nil {
@@ -42,9 +44,6 @@ func init() {
 }
 
 func describeNode(args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("Please provide the node you want to get description for: [type_of_node:attribute:value]")
-	}
 	node, err := ParseNodeID(args[0])
 	if err != nil {
 		return err


### PR DESCRIPTION
Provide a better description of the commands to the user.
The generic syntax that is being used by the commands [<type_of_node:attribute:value>]
has to be mentioned in the command description.