### PR TITLE
[qmstrctl] cancel timeout if only waiting for inserts

### DIFF
--- a/lib/go-qmstr/docker/client.go
+++ b/lib/go-qmstr/docker/client.go
@@ -78,6 +78,7 @@ func RunClientContainer(ctx context.Context, cli *client.Client, clientConfig *C
 	if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
 		return err
 	}
+	log.Printf("Build container %s started", resp.ID)
 
 	status, err := cli.ContainerWait(ctx, resp.ID)
 	if err != nil {


### PR DESCRIPTION
Cancel the connection timeout because it is not useful to wait for the
whole insert queue to be done in 60 seconds.