### PR TITLE
Extensions for the validator concept

### DIFF
--- a/doc/content/WIP/validation/_index.md
+++ b/doc/content/WIP/validation/_index.md
@@ -48,7 +48,8 @@ depends on which of the checks failed (1, 2 or 3). If the validation
 succeeds the return code is zero.
 
 Depending on the file format, the manifest file may be included in the
-package. Support for that may be added to the validator.
+package. Each container format has known metadata only files that are
+ignored by or used as manifests for the validator.
 
 ## Verifying distributions
 
@@ -57,8 +58,10 @@ shipped together as a unit. The validator can be used to evaluate
 distributions. The validation succeeds if the validation for each
 package contained in the distribution succeeds.
 
-TODO How this can be done has to be developed and depends on how
-distributions are represented.
+This can be invoked the same way as any other container format.
+
+    > qmstr validate ubuntu-bionic.img ubuntu-bionic.spdx
+    <TODO output>
 
 ## Development plan
 


### PR DESCRIPTION
* package = the metadata we have in our graph or read from a manifest (e.g. SPDX) representing a single package
* container = the "evelope" :/ that holds files (damn you container technology)
* manifest/metadata = produced by instrumented build or provided, consumed by validator

The manifest has at leat full path to file and a signature and can describe one or many packages.

The container is a flat file system. It has files that need validation and metadata. Containers can nest indefinitely as long as there are rules on what files are what so they don't count as files that are not described by the manifest -> fail. Each format specifies 2 methods. getFiles which should at leat return full path to file and a signature and getMeta that should parse whatever metadata files there is.

For example in the case of deb package it doesn't make sense to treat it as an ar container because the getFiles should return control.tar.gz and data.tar.gz and getMeta nothing.

A "distribution" or a collection container can be of 2 types. A flat file system that has each binary and conf files, etc. already at place (e.g. ubuntu-cloud-img) so the manifest has a list of packages with files that can be hashed at place or it can be a collection of nested package containers that may need to be handled recursively (a tar of dep packages??)