### PR TITLE
Fix documentation dependencies

### DIFF
--- a/doc/Makefile.common
+++ b/doc/Makefile.common
@@ -12,11 +12,11 @@ $(GOHUGO):
 	@cd $(HUGOTMP)/hugo && go install --tags extended
 	@rm -fr $(HUGOTMP)/hugo
 
-doc/content/reference/qmstrctl.md : clients
-	${OUTDIR}qmstrctl dev-generate-reference -b /reference doc/content/reference/
+doc/content/reference/qmstrctl.md : $(OUTDIR)qmstrctl
+	$^ dev-generate-reference -b /reference doc/content/reference/
 
-doc/content/reference/qmstr.md : clients
-	${OUTDIR}qmstr dev-generate-reference -b /reference doc/content/reference/
+doc/content/reference/qmstr.md : $(OUTDIR)qmstr
+	$^ dev-generate-reference -b /reference doc/content/reference/
 
 doc/documentation: $(HUGO) doc/content/reference/qmstrctl.md doc/content/reference/qmstr.md
 	@cd doc && $(HUGO) -d documentation


### PR DESCRIPTION
The dependencies are the actual binaries to be called.