### PR TITLE
HOTFIX [master] check for empty package on query

### DIFF
--- a/lib/go-qmstr/cli/update.go
+++ b/lib/go-qmstr/cli/update.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/QMSTR/qmstr/lib/go-qmstr/service"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
@@ -98,13 +99,13 @@ func updateNode(nodeIdent string) error {
 			return fmt.Errorf("Failed sending FileNode: %v", err)
 		}
 	case *service.PackageNode:
-		currentNode, err = controlServiceClient.GetPackageNode(context.Background(), cNode)
+		currentNode, err := getUniquePackageNode(cNode)
 		if err != nil {
 			return fmt.Errorf("Failed to get package node: %v", err)
 		}
 		// set fields of node according to flags
 		cmdFlags.Visit(visitNodeFlag)
-		res, err := buildServiceClient.CreatePackage(context.Background(), currentNode.(*service.PackageNode))
+		res, err := buildServiceClient.CreatePackage(context.Background(), currentNode)
 		if err != nil {
 			return err
 		}

--- a/lib/go-qmstr/master/master.go
+++ b/lib/go-qmstr/master/master.go
@@ -87,7 +87,7 @@ func (s *server) UpdatePackageNode(ctx context.Context, in *service.UpdatePackag
 		return nil, err
 	}
 	in.Package.Targets = append(in.Package.Targets, in.Targets...)
-	log.Printf("Adding package node %s", in.Package.Name)
+	log.Printf("Updating package node %s", in.Package.Name)
 	db.AddPackageNode(in.Package)
 	return &service.BuildResponse{Success: true}, nil
 }
@@ -122,7 +122,7 @@ func (s *server) GetPackageNode(in *service.PackageNode, stream service.ControlS
 		return err
 	}
 	var packages []*service.PackageNode
-	if in.IsValid() {
+	if !in.IsEmpty() {
 		node, err := db.GetPackageNodeByName(in.Name)
 		if err != nil {
 			return err

--- a/lib/go-qmstr/service/common.go
+++ b/lib/go-qmstr/service/common.go
@@ -1,8 +1,10 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 )
 
@@ -97,6 +99,28 @@ func (fn *FileNode) IsValid() bool {
 
 func (pn *PackageNode) IsValid() bool {
 	return pn.Name != "" && pn.Version != ""
+}
+
+func checkEmpty(structure interface{}) error {
+	val := reflect.ValueOf(structure)
+	for val.Kind() == reflect.Ptr || val.Kind() == reflect.Interface {
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return errors.New("provided non-struct")
+	}
+
+	if !reflect.DeepEqual(val.Interface(), reflect.Zero(val.Type()).Interface()) {
+		return errors.New("non empty struct")
+	}
+
+	return nil
+}
+
+func (pn *PackageNode) IsEmpty() bool {
+	err := checkEmpty(pn)
+	return err == nil
 }
 
 func (prn *ProjectNode) IsValid() bool {

--- a/lib/go-qmstr/service/common_test.go
+++ b/lib/go-qmstr/service/common_test.go
@@ -1,0 +1,25 @@
+package service 
+
+import "testing"
+import "log"
+
+type Dummy struct {
+	a string
+	b int64
+	c []Dummy
+}
+
+func TestCheckEmpty(t *testing.T) {
+	d := Dummy{}
+	err := checkEmpty(&d)
+	if err != nil {
+		log.Println(err)
+		t.Fail()
+	}
+
+	d.a = "Test"
+	err = checkEmpty(&d)
+	if err == nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Check for an empty package before returning all package nodes. Checking
for valid package node will fail whenever there is only name or version
provided in the query node.