### PR TITLE
Skip content if the variable is empty

### DIFF
--- a/lib/go-qmstr/reporting/package_data.go
+++ b/lib/go-qmstr/reporting/package_data.go
@@ -2,6 +2,7 @@ package reporting
 
 import (
 	"encoding/json"
+
 	"github.com/QMSTR/qmstr/lib/go-qmstr/service"
 )
 
@@ -37,7 +38,7 @@ func GetPackageData(pkg *service.PackageNode, projectName string) *PackageData {
 		// reduce returned data
 		fileNode.DerivedFrom = []*service.FileNode{}
 		fileNode.Dependencies = []*service.FileNode{}
-		targets = append(targets, &Target{Target: fileNode})
+		targets = append(targets, &Target{Target: fileNode, Licenses: []string{}, Authors: []string{}})
 	}
 	packageData.Targets = targets
 

--- a/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/authors.html
+++ b/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/authors.html
@@ -1,7 +1,8 @@
-{{ $data := index .Site.Data .Page.Params.project .Page.Params.package .Page.Params.version "data" }} 
+{{ with $data := index .Site.Data .Page.Params.project .Page.Params.package .Page.Params.version "data" }}
 <h3>Authors</h3>
 <ul>
 {{ range $data.Authors }}
     <li>{{ . }}</li>
 {{ end }}
 </ul>
+{{ end }}

--- a/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/licenses.html
+++ b/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/licenses.html
@@ -1,7 +1,8 @@
-{{ $data := index .Site.Data .Page.Params.project .Page.Params.package .Page.Params.version "data" }} 
+{{ with $data := index .Site.Data .Page.Params.project .Page.Params.package .Page.Params.version "data" }}
 <h3>Licenses</h3>
 <ul>
 {{ range $data.Licenses }}
     <li>{{ . }}</li>
     {{ end }}
 </ul>
+{{ end }}

--- a/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/target-list.html
+++ b/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/target-list.html
@@ -1,7 +1,8 @@
-{{ $data := index .Site.Data .Page.Params.project .Page.Params.package .Page.Params.version "data" }}
+{{ with $data := index .Site.Data .Page.Params.project .Page.Params.package .Page.Params.version "data" }}
 <h3>Targets:</h3>
 {{ range $data.Targets }}
     <p> Filename: <b>{{ .Target.path }}</b></p>
     SHA-1: {{ .Target.hash }} <br/>
     licenses: {{ delimit .Licenses ", " }}<br/>
+{{ end }}
 {{ end }}


### PR DESCRIPTION
This PR fixes html reporter. 
In case the package is connected to a target with no license or copyright info, then the corresponding html scripts should not fail.