### PR TITLE
Prevent HTML failures with slashes '/' and empty arrays

### DIFF
--- a/lib/go-qmstr/reporting/package_data.go
+++ b/lib/go-qmstr/reporting/package_data.go
@@ -2,6 +2,7 @@ package reporting
 
 import (
 	"encoding/json"
+
 	"github.com/QMSTR/qmstr/lib/go-qmstr/service"
 )
 
@@ -31,6 +32,10 @@ func GetPackageData(pkg *service.PackageNode, projectName string) *PackageData {
 	if packageData.Version == "" {
 		packageData.Version = "default"
 	}
+
+	packageData.Project = service.RemoveSlash(packageData.Project)
+	packageData.Name = service.RemoveSlash(packageData.Name)
+	packageData.Version = service.RemoveSlash(packageData.Version)
 
 	targets := []*Target{}
 	for _, fileNode := range pkg.GetTargets() {

--- a/lib/go-qmstr/service/common.go
+++ b/lib/go-qmstr/service/common.go
@@ -155,3 +155,8 @@ func getMetaData(key string, info []*InfoNode) (string, error) {
 	}
 	return "", fmt.Errorf("No metadata found for key %s", key)
 }
+
+func RemoveSlash(value string) string {
+	newvalue := strings.Replace(value, "/", "_", -1)
+	return newvalue
+}

--- a/modules/reporters/qmstr-reporter-html/package_reports.go
+++ b/modules/reporters/qmstr-reporter-html/package_reports.go
@@ -35,14 +35,14 @@ func (r *HTMLReporter) CreatePackageLevelReports(proj *service.ProjectNode, pkg 
 	}
 
 	contentDirectory := path.Join(r.workingDir, "content")
-	projectContentDirectory := path.Join(contentDirectory, proj.Name)
-	packageContentDirectory := path.Join(projectContentDirectory, pkg.Name)
-	versionContentDirectory := path.Join(packageContentDirectory, pkg.Version)
+	projectContentDirectory := path.Join(contentDirectory, packageData.Project)
+	packageContentDirectory := path.Join(projectContentDirectory, packageData.Name)
+	versionContentDirectory := path.Join(packageContentDirectory, packageData.Version)
 
 	dataDirectory := path.Join(r.workingDir, "data")
-	projectDirectory := path.Join(dataDirectory, proj.Name)
-	packageDirectory := path.Join(projectDirectory, pkg.Name)
-	versionDirectory := path.Join(packageDirectory, pkg.Version)
+	projectDirectory := path.Join(dataDirectory, packageData.Project)
+	packageDirectory := path.Join(projectDirectory, packageData.Name)
+	versionDirectory := path.Join(packageDirectory, packageData.Version)
 
 	if err := os.MkdirAll(versionDirectory, os.ModePerm); err != nil {
 		return fmt.Errorf("error creating package metadata directory: %v", err)

--- a/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/target-list.html
+++ b/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/target-list.html
@@ -3,5 +3,8 @@
 {{ range $data.Targets }}
     <p> Filename: <b>{{ .Target.path }}</b></p>
     SHA-1: {{ .Target.hash }} <br/>
-    licenses: {{ delimit .Licenses ", " }}<br/>
+    Licenses: 
+    {{ with .Licenses -}}
+        {{- delimit . ", " -}}
+    {{- end -}}<br/>
 {{ end }}


### PR DESCRIPTION
Now the HTML Reporter uses the common function `RemoveSlash` to replace it with an underscore in packages and project names, preventing the creation of subfolders and inconsistencies between file structures and references inside Hugo building phase.

_A suggestion for the future is to update this function to remove any kind of special character across phases, to prevent related bugs._

It was also added a Hugo function to wrap arrays, making sure that Hugo can build properly even if it's an empty array.

<br>

Fix #382, fix #385 