### PR TITLE
[deb pkg] Validate only regular files.

### DIFF
--- a/modules/packages/deb.go
+++ b/modules/packages/deb.go
@@ -93,7 +93,7 @@ func NewDebPackage(in io.Reader) (*DebPackage, error) {
 			return nil, fmt.Errorf("deb pkg: data archive: %v", err)
 		}
 
-		if !thdr.FileInfo().IsDir() {
+		if thdr.FileInfo().Mode().IsRegular() {
 			h, err := common.Hash(tarr)
 			if err != nil {
 				return nil, fmt.Errorf("deb pkg: hashing file %s: %v", thdr.Name, err)


### PR DESCRIPTION
The previous implementation of deb package was ignoring only directories.
This change checks only for regular files to avoid situations that the
file in check is a symbolic link that might or might not point to a file
in the archive.