### PR TITLE
absolute paths in python

### DIFF
--- a/lib/pyqmstr/qmstr/module/utils.py
+++ b/lib/pyqmstr/qmstr/module/utils.py
@@ -17,6 +17,8 @@ def get_files_list(path):
     Returns a list of all files from a given directory, including its
     subfolders.
     """
+    path = os.path.abspath(path)
+
     all_files = []
 
     for dirpath, dirnames, filenames in os.walk(path, topdown=True):
@@ -59,6 +61,8 @@ def new_file_node(path, hash=False):
     """
     Returns a filenode with calculated checksum if hash parameter is True
     """
+
+    path = os.path.abspath(path)
 
     if hash:
         chksum = hash_file(path)

--- a/modules/builders/qmstr-py-builder/qmstrpybuilder/bdistbuilder.py
+++ b/modules/builders/qmstr-py-builder/qmstrpybuilder/bdistbuilder.py
@@ -11,7 +11,6 @@ class BdistBuilder(QMSTR_Builder):
         self.temp_dir = temp_dir
 
     def configure(self):
-        # TODO: do we need it?
         pass
 
     def index(self):


### PR DESCRIPTION
Use absolute paths to make sure path substitution works.