### PR TITLE
280 leaves query

### DIFF
--- a/lib/go-qmstr/database/diagnosticNode.go
+++ b/lib/go-qmstr/database/diagnosticNode.go
@@ -12,7 +12,7 @@ import (
 	"github.com/QMSTR/qmstr/lib/go-qmstr/service"
 )
 
-// AddDiagnosticNodes stores the given DiagnosticNodes in a PackageNode or FileNode identified by the nodeID
+// AddDiagnosticNode stores the given DiagnosticNodes in a PackageNode or FileNode identified by the nodeID
 func (db *DataBase) AddDiagnosticNode(nodeID string, diagnosticnode *service.DiagnosticNode) error {
 	db.insertMutex.Lock()
 	defer db.insertMutex.Unlock()


### PR DESCRIPTION
On order to remove the fileType field in file nodes we need to query for
source file nodes. This information is already in the graph. Every leaf
filenode is considered a source as it was not derived from other
filenodes.

closes #280 