### PR TITLE
add ci config & tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "doc/themes/hugo-theme-techdoc"]
 	path = doc/themes/hugo-theme-techdoc
 	url = https://github.com/thingsym/hugo-theme-techdoc.git
+[submodule "demos"]
+	path = demos
+	url = https://github.com/endocode/qmstr-demo.git

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,11 +30,8 @@ pipeline {
                         sh 'export PATH=$PATH:$PWD/out/'
                         sh 'make container'
                         sh 'git submodule update --init'
-                        sh 'echo $PATH'
-                        dir('demos') {
-                           sh 'echo $PATH'
-                           sh "make curl"
-                        }
+                        sh "cd demos && make curl"
+                       
                     }
                 }
 
@@ -47,9 +44,7 @@ pipeline {
                         sh 'export PATH=$PATH:$PWD/out/'
                         sh 'make container'
                         sh 'git submodule update --init'
-                        dir('demos') {
-                           sh "make openssl"
-                        }
+                        sh "cd demos && make openssl"
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,9 @@ pipeline {
                         unstash 'executables'
                         sh 'export PATH=$PATH:$PWD/out/'
                         sh 'git submodule update --init'
-                        sh 'cd demos && make curl'
+                        dir('demos') {
+                           sh "make curl"
+                        }
                     }
                 }
 
@@ -45,7 +47,9 @@ pipeline {
                         unstash 'executables'
                         sh 'export PATH=$PATH:$PWD/out/'
                         sh 'git submodule update --init'
-                        sh 'cd demos && make openssl'
+                        dir('demos') {
+                           sh "make openssl"
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     agent none
 
     environment {
-        PATH = "/tmp:$PATH"
+        PATH = "/tmp:${env.PATH}"
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,10 @@ pipeline {
 
     agent none
 
+    environment {
+        PATH = "/tmp:$PATH"
+    }
+
     stages {
 
         stage('Build & Test') {
@@ -30,6 +34,7 @@ pipeline {
                         sh 'export PATH=$PATH:$PWD/out/'
                         sh 'make container'
                         sh 'git submodule update --init'
+                        sh 'echo $PATH'
                         sh "cd demos && make curl"
                        
                     }
@@ -44,6 +49,7 @@ pipeline {
                         sh 'export PATH=$PATH:$PWD/out/'
                         sh 'make container'
                         sh 'git submodule update --init'
+                        sh 'echo $PATH'
                         sh "cd demos && make openssl"
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,13 @@ pipeline {
             }
         }
 
+        stage('compile curl'){
+            steps{
+                sh 'cp out/qmstr* /usr/local/bin'
+                sh 'cd demos && make curl'
+            }
+        }
+
     }
 
     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     stages {
         stage('Clean') {
             steps {
-                cleanWs()
+                sh 'git clean -f -d'
             }
         }
  

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,6 @@ pipeline {
 
     agent none
 
-    environment {
-        PATH = "/tmp:${env.PATH}"
-    }
-
     stages {
 
         stage('Build & Test') {
@@ -29,6 +25,10 @@ pipeline {
 
                     agent { label 'docker' }
 
+                    environment {
+                        PATH = "/tmp:$PATH"
+                    }
+
                     steps {
                         unstash 'executables'
                         sh 'export PATH=$PATH:$PWD/out/'
@@ -43,6 +43,10 @@ pipeline {
                 stage('compile openssl'){
 
                     agent { label 'docker' }
+
+                    environment {
+                        PATH = "/tmp:$PATH"
+                    }
 
                     steps {
                         unstash 'executables'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,9 @@ pipeline {
                     sh 'make democontainer'
                     def mastername = sh(script: 'docker create qmstr/master', returnStdout: true)
                     mastername = mastername.trim()
-                    sh "sudo docker cp ${mastername}:/usr/local/bin/qmstr out/qmstr"
-                    sh "sudo docker cp ${mastername}:/usr/local/bin/qmstrctl out/qmstrctl"
+                    sh 'mkdir out'
+                    sh "docker cp ${mastername}:/usr/local/bin/qmstr out/qmstr"
+                    sh "docker cp ${mastername}:/usr/local/bin/qmstrctl out/qmstrctl"
                     sh "docker rm ${mastername}"
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,9 @@ pipeline {
                         sh 'export PATH=$PATH:$PWD/out/'
                         sh 'make container'
                         sh 'git submodule update --init'
+                        sh 'echo $PATH'
                         dir('demos') {
+                           sh 'echo $PATH'
                            sh "make curl"
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                     agent { label 'docker' }
 
                     environment {
-                        PATH = "/tmp:$PATH"
+                        PATH = "$PATH:$WORKSPACE/out/"
                     }
 
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,6 @@ pipeline {
 
     agent none
 
-    environment {
-        MASTER_CONTAINER_NAME="qmstr-demo-master_${BUILD_NUMBER}"
-    }
-
     stages {
 
         stage('Build & Test') {
@@ -30,8 +26,7 @@ pipeline {
                     agent { label 'docker' }
 
                     steps {
-                        unstash 'executables'
-                        sh 'export PATH=$PATH:$PWD/out/'
+                        sh 'make container'
                         sh 'git submodule update --init'
                         dir('demos') {
                            sh "make curl"
@@ -44,8 +39,7 @@ pipeline {
                     agent { label 'docker' }
 
                     steps {
-                        unstash 'executables'
-                        sh 'export PATH=$PATH:$PWD/out/'
+                        sh 'make container'
                         sh 'git submodule update --init'
                         dir('demos') {
                            sh "make openssl"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         stage('compile curl'){
             steps{
                 sh 'export PATH=$PATH:$PWD/out/'
-                sh 'git submodule init'
+                sh 'git submodule update --init'
                 sh 'cd demos && make curl'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,36 @@
+pipeline {
+    agent { label 'golang' }
+    // fixme: this is wrong - the makefile requires golang for some reason. That should not be necessary when building in containers
+
+    environment {
+        MASTER_CONTAINER_NAME="qmstr-demo-master_${BUILD_NUMBER}"
+    }
+
+    stages {
+        stage('Clean') {
+            steps {
+                cleanWs()
+            }
+        }
+ 
+        stage('Build master and client images') {
+            steps {
+                script {
+                    sh 'make democontainer'
+                    def mastername = sh(script: 'docker create qmstr/master', returnStdout: true)
+                    mastername = mastername.trim()
+                    sh "sudo docker cp ${mastername}:/usr/local/bin/qmstr out/qmstr"
+                    sh "sudo docker cp ${mastername}:/usr/local/bin/qmstrctl out/qmstrctl"
+                    sh "docker rm ${mastername}"
+                }
+            }
+        }
+    }
+
+    post {
+        success {
+            archiveArtifacts artifacts: 'out/*', fingerprint: true
+        }
+    }
+
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,8 @@ pipeline {
                     agent { label 'docker' }
 
                     steps {
+                        unstash 'executables'
+                        sh 'export PATH=$PATH:$PWD/out/'
                         sh 'make container'
                         sh 'git submodule update --init'
                         dir('demos') {
@@ -39,6 +41,8 @@ pipeline {
                     agent { label 'docker' }
 
                     steps {
+                        unstash 'executables'
+                        sh 'export PATH=$PATH:$PWD/out/'
                         sh 'make container'
                         sh 'git submodule update --init'
                         dir('demos') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,12 +23,11 @@ pipeline {
 
                 stage('compile curl'){
 
-                    agent { label 'docker' }
-
                     environment {
-                        //PATH = "/tmp:$PATH"
                         PATH = "$PATH:$WORKSPACE/out/"
                     }
+
+                    agent { label 'docker' }
 
                     steps {
                         unstash 'executables'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,14 +15,16 @@ pipeline {
             steps {
                 sh "make clients"
                 sh "make gotest"
+                stash includes: 'out/qmstr*', name: 'executables' 
             }
-            stash includes: 'out/qmstr*', name: 'executables' 
+            
         }
 
         stage('compile curl'){
             agent { label 'docker' }
-            unstash 'executables'
+            
             steps{
+                unstash 'executables'
                 sh 'export PATH=$PATH:$PWD/out/'
                 sh 'git submodule update --init'
                 sh 'cd demos && make curl'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,12 @@ pipeline {
             }
         }
 
+        stage('Test') {
+            steps {
+                sh "make gotest"
+            }
+        }
+
     }
 
     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,12 +26,12 @@ pipeline {
                     agent { label 'docker' }
 
                     environment {
-                        PATH = "/tmp:$PATH"
+                        //PATH = "/tmp:$PATH"
+                        PATH = "$PATH:$PWD/out/"
                     }
 
                     steps {
                         unstash 'executables'
-                        sh 'export PATH=$PATH:$PWD/out/'
                         sh 'make container'
                         sh 'git submodule update --init'
                         sh 'echo $PATH'
@@ -50,7 +50,6 @@ pipeline {
 
                     steps {
                         unstash 'executables'
-                        sh 'export PATH=$PATH:$PWD/out/'
                         sh 'make container'
                         sh 'git submodule update --init'
                         sh 'echo $PATH'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,31 +1,21 @@
 pipeline {
-    agent { label 'golang' }
-    // fixme: this is wrong - the makefile requires golang for some reason. That should not be necessary when building in containers
+
+    agent {
+        docker { image 'endocode/qmstr_buildenv:latest' }
+    }
 
     environment {
         MASTER_CONTAINER_NAME="qmstr-demo-master_${BUILD_NUMBER}"
     }
 
     stages {
-        stage('Clean') {
+
+        stage('Build') {
             steps {
-                sh 'git clean -f -d'
+                sh "make clients"
             }
         }
- 
-        stage('Build master and client images') {
-            steps {
-                script {
-                    sh 'make democontainer'
-                    def mastername = sh(script: 'docker create qmstr/master', returnStdout: true)
-                    mastername = mastername.trim()
-                    sh 'mkdir out'
-                    sh "docker cp ${mastername}:/usr/local/bin/qmstr out/qmstr"
-                    sh "docker cp ${mastername}:/usr/local/bin/qmstrctl out/qmstrctl"
-                    sh "docker rm ${mastername}"
-                }
-            }
-        }
+
     }
 
     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,6 @@ pipeline {
                         unstash 'executables'
                         sh 'make container'
                         sh 'git submodule update --init'
-                        sh 'echo $PATH'
                         sh "cd demos && make curl"
                        
                     }
@@ -51,7 +50,6 @@ pipeline {
                         unstash 'executables'
                         sh 'make container'
                         sh 'git submodule update --init'
-                        sh 'echo $PATH'
                         sh "cd demos && make openssl"
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
 
                     environment {
                         //PATH = "/tmp:$PATH"
-                        PATH = "$PATH:$PWD/out/"
+                        PATH = "$PATH:$WORKSPACE/out/"
                     }
 
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,27 +16,41 @@ pipeline {
                 sh "make clients"
                 sh "make gotest"
                 stash includes: 'out/qmstr*', name: 'executables' 
+                archiveArtifacts artifacts: 'out/*', fingerprint: true
             }
             
         }
 
-        stage('compile curl'){
-            agent { label 'docker' }
-            
-            steps{
-                unstash 'executables'
-                sh 'export PATH=$PATH:$PWD/out/'
-                sh 'git submodule update --init'
-                sh 'cd demos && make curl'
+        stage('Compile with QMSTR'){
+
+            parallel{
+
+                stage('compile curl'){
+
+                    agent { label 'docker' }
+
+                    steps {
+                        unstash 'executables'
+                        sh 'export PATH=$PATH:$PWD/out/'
+                        sh 'git submodule update --init'
+                        sh 'cd demos && make curl'
+                    }
+                }
+
+                stage('compile openssl'){
+
+                    agent { label 'docker' }
+
+                    steps {
+                        unstash 'executables'
+                        sh 'export PATH=$PATH:$PWD/out/'
+                        sh 'git submodule update --init'
+                        sh 'cd demos && make openssl'
+                    }
+                }
             }
         }
 
-    }
-
-    post {
-        success {
-            archiveArtifacts artifacts: 'out/*', fingerprint: true
-        }
     }
 
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline {
 
         stage('compile curl'){
             steps{
-                sh 'cp out/qmstr* /usr/local/bin'
+                sh 'export PATH=$PATH:$PWD/out/'
+                sh 'git submodule init'
                 sh 'cd demos && make curl'
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ gofmt: $(GO) $(GO_SRCS)
 	$(GO) fmt $(GO_PKGS) $(GO_MODULE_PKGS)
 
 .PHONY: gotest
-gotest: .go_qmstr_test .go_module_test
+gotest: $(GO_DEPS) .go_qmstr_test .go_module_test
 
 .PHONY: govet
 govet: $(GO_SRCS) $(GO) gofmt


### PR DESCRIPTION
we want to reduce the requirements on the build environment so a docker image was created at endocode/qmstr_buildenv which will be used by the CI to test & build qmstr. Artifacts are stored & published on endocodes CI system.

The demo repository is now linked into the parent repository so there is a defined state of application & test environment