### PR TITLE
Add SPDX copyright data to file nodes

### DIFF
--- a/lib/go-qmstr/reporting/package_data.go
+++ b/lib/go-qmstr/reporting/package_data.go
@@ -17,9 +17,10 @@ type PackageData struct {
 }
 
 type Target struct {
-	Target   *service.FileNode
-	Licenses []string
-	Authors  []string
+	Target     *service.FileNode
+	Licenses   []string
+	Authors    []string
+	Copyrights []string
 }
 
 func GetPackageData(pkg *module.PackageNodeProxy, projectName string) (*PackageData, error) {
@@ -51,6 +52,7 @@ func GetPackageData(pkg *module.PackageNodeProxy, projectName string) (*PackageD
 	return &packageData, nil
 }
 
+// TODO: GetAuthors, GetLicenses and GetCopyrights can be a single function!
 func (p *PackageData) GetAuthors() []string {
 	authors := map[string]struct{}{}
 	for _, target := range p.Targets {
@@ -83,15 +85,33 @@ func (p *PackageData) GetLicenses() []string {
 	return uniqLicenses
 }
 
+func (p *PackageData) GetCopyrights() []string {
+	copyrights := map[string]struct{}{}
+	for _, target := range p.Targets {
+		for _, copyright := range target.Copyrights {
+			copyrights[copyright] = struct{}{}
+		}
+	}
+
+	uniqCopyrights := []string{}
+
+	for copyright := range copyrights {
+		uniqCopyrights = append(uniqCopyrights, copyright)
+	}
+	return uniqCopyrights
+}
+
 func (p *PackageData) MarshalJSON() ([]byte, error) {
 	type Alias PackageData
 	return json.Marshal(&struct {
-		Authors  []string
-		Licenses []string
+		Authors    []string
+		Licenses   []string
+		Copyrights []string
 		*Alias
 	}{
-		Authors:  p.GetAuthors(),
-		Licenses: p.GetLicenses(),
-		Alias:    (*Alias)(p),
+		Authors:    p.GetAuthors(),
+		Licenses:   p.GetLicenses(),
+		Copyrights: p.GetCopyrights(),
+		Alias:      (*Alias)(p),
 	})
 }

--- a/modules/analyzers/spdx-analyzer/spdxanalyzer/__main__.py
+++ b/modules/analyzers/spdx-analyzer/spdxanalyzer/__main__.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python2
 import argparse
-from qmstr.service.datamodel_pb2 import FileNode, InfoNode, PackageNode
-from qmstr.service.controlservice_pb2 import GetFileNodeMessage
+from qmstr.service.datamodel_pb2 import InfoNode, PackageNode
 from qmstr.service.analyzerservice_pb2 import InfoNodesMessage, DummyRequest
 from qmstr.module.module import QMSTR_Analyzer
 from qmstr.module.utils import generate_iterator
 from spdx.document import License
+from spdx.utils import SPDXNone, NoAssert
 import logging
 import sys
 
@@ -46,14 +46,14 @@ class SpdxAnalyzer(QMSTR_Analyzer):
 
     def configure(self, config_map):
         logging.info("Configuring spdx analyzer module")
-        if not filename_key in config_map:
+        if filename_key not in config_map:
             logging.error(
                 "spdx-analyzer misconfigured. {} missing.".format(filename_key))
             sys.exit(2)
         else:
             self.spdx_file = config_map[filename_key]
 
-        if not fileformat_key in config_map:
+        if fileformat_key not in config_map:
             if self.spdx_file.endswith(".rdf"):
                 self.format = "rdf"
             elif self.spdx_file.endswith(".tag"):
@@ -69,6 +69,16 @@ class SpdxAnalyzer(QMSTR_Analyzer):
         self._process_filenodes()
         self._process_packagenode()
 
+    def _send_infonodes(self, node_uid, info_nodes):
+        info_nodes_msgs = []
+        info_nodes_msgs.append(InfoNodesMessage(
+            uid=node_uid,
+            token=self.token,
+            infonodes=info_nodes))
+        info_iterator = generate_iterator(info_nodes_msgs)
+        
+        self.aserv.SendInfoNodes(info_iterator)
+
     def _process_filenodes(self):
 
         stream_resp = self.aserv.GetSourceFileNodes(DummyRequest())
@@ -82,35 +92,53 @@ class SpdxAnalyzer(QMSTR_Analyzer):
                     "File {} not found in SPDX document".format(node.path))
                 continue
             spdx_doc_file_info = filtered_files[0]
-            if not isinstance(spdx_doc_file_info.conc_lics, License):
-                continue
-
-            data_nodes = []
-            logging.info("Concluded license {}".format(
-                spdx_doc_file_info.conc_lics))
-            data_nodes.append(InfoNode.DataNode(
-                type="spdxIdentifier",
-                data=spdx_doc_file_info.conc_lics.identifier
-            ))
-            data_nodes.append(InfoNode.DataNode(
-                type="name",
-                data=spdx_doc_file_info.conc_lics.full_name
-            ))
 
             info_nodes = []
-            info_nodes.append(InfoNode(
-                type="license",
-                dataNodes=data_nodes))
 
-            info_nodes_msgs = []
-            info_nodes_msgs.append(InfoNodesMessage(
-                uid=node.fileData.uid,
-                token=self.token,
-                infonodes=info_nodes))
+            if isinstance(spdx_doc_file_info.conc_lics, License):
+                data_nodes = []
+                logging.info("Concluded license {}".format(
+                    spdx_doc_file_info.conc_lics))
+                data_nodes.append(
+                    InfoNode.DataNode(
+                        type="spdxIdentifier",
+                        data=spdx_doc_file_info.conc_lics.identifier
+                    )
+                )
+                data_nodes.append(
+                    InfoNode.DataNode(
+                        type="name",
+                        data=spdx_doc_file_info.conc_lics.full_name
+                    )
+                )
 
-            info_iterator = generate_iterator(info_nodes_msgs)
+                info_nodes.append(
+                    InfoNode(
+                        type="license",
+                        dataNodes=data_nodes
+                    )
+                )
 
-            self.aserv.SendInfoNodes(info_iterator)
+            if isinstance(spdx_doc_file_info.copyright, (str, SPDXNone, NoAssert)):
+                data_nodes = []
+                logging.info("Copyright text: {}".format(
+                    spdx_doc_file_info.copyright))
+                data_nodes.append(
+                    InfoNode.DataNode(
+                        type="text",
+                        data=spdx_doc_file_info.copyright
+                    )
+                )
+
+                info_nodes.append(
+                    InfoNode(
+                        type="copyright",
+                        dataNodes=data_nodes
+                    )
+                )
+
+            if info_nodes:
+                self._send_infonodes(node.fileData.uid, info_nodes)
 
     def post_analyze(self):
         pass
@@ -145,24 +173,16 @@ class SpdxAnalyzer(QMSTR_Analyzer):
                 type="metadata",
                 dataNodes=data_nodes))
 
-            info_nodes_msgs = []
-            info_nodes_msgs.append(InfoNodesMessage(
-                uid=package_node.uid,
-                token=self.token,
-                infonodes=info_nodes))
-
-            info_iterator = generate_iterator(info_nodes_msgs)
-
-            self.aserv.SendInfoNodes(info_iterator)
+            self._send_infonodes(package_node.uid, info_nodes)
 
     def _parse_spdx(self):
-        if not self.format in self.parse_func_map:
+        if self.format not in self.parse_func_map:
             logging.error("Unsupported format {}".format(self.format))
             sys.exit(4)
         with open(self.spdx_file, "r") as spdxfile:
             spdxdata = spdxfile.read()
             doc, error = self.parse_func_map[self.format](spdxdata)
-            if error != None:
+            if error is not None:
                 logging.error(error)
                 sys.exit(5)
             return doc

--- a/modules/analyzers/spdx-analyzer/spdxanalyzer/__main__.py
+++ b/modules/analyzers/spdx-analyzer/spdxanalyzer/__main__.py
@@ -76,7 +76,7 @@ class SpdxAnalyzer(QMSTR_Analyzer):
             token=self.token,
             infonodes=info_nodes))
         info_iterator = generate_iterator(info_nodes_msgs)
-        
+
         self.aserv.SendInfoNodes(info_iterator)
 
     def _process_filenodes(self):

--- a/modules/reporters/qmstr-reporter-html/package_reports.go
+++ b/modules/reporters/qmstr-reporter-html/package_reports.go
@@ -24,6 +24,7 @@ func (r *HTMLReporter) CreatePackageLevelReports(proj *service.ProjectNode, pkg 
 	for _, target := range packageData.Targets {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		// TODO: Reduce duplicate code creating a function to get and append the infodata
 		resp, err := pkg.GetMasterClient().RptSvcClient.GetInfoData(ctx, &service.InfoDataRequest{RootID: target.Target.Uid, Infotype: "license", Datatype: "name"})
 		if err != nil {
 			return err
@@ -35,6 +36,12 @@ func (r *HTMLReporter) CreatePackageLevelReports(proj *service.ProjectNode, pkg 
 			return err
 		}
 		target.Authors = append(target.Authors, resp.Data...)
+
+		resp, err = pkg.GetMasterClient().RptSvcClient.GetInfoData(ctx, &service.InfoDataRequest{RootID: target.Target.Uid, Infotype: "copyright", Datatype: "text"})
+		if err != nil {
+			return err
+		}
+		target.Copyrights = append(target.Copyrights, resp.Data...)
 	}
 
 	contentDirectory := path.Join(r.workingDir, "content")

--- a/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/copyrights.html
+++ b/modules/reporters/qmstr-reporter-html/share/skeleton/layouts/shortcodes/copyrights.html
@@ -1,0 +1,9 @@
+{{ $data := index .Site.Data .Page.Params.project .Page.Params.package .Page.Params.version "data" }} 
+{{- with $data.Copyrights -}}
+    <h3>Copyright</h3>
+    <ul>
+    {{ range . }}
+        <li>{{ . }}</li>
+        {{ end }}
+    </ul>
+{{- end -}}

--- a/modules/reporters/qmstr-reporter-html/share/templates/version-index.md
+++ b/modules/reporters/qmstr-reporter-html/share/templates/version-index.md
@@ -12,4 +12,6 @@ weight = 1
 
 {{< authors >}}
 
+{{< copyrights >}}
+
 {{< target-list >}}


### PR DESCRIPTION
Fix #318

![Screenshot from 2020-01-10 18-14-23](https://user-images.githubusercontent.com/10999758/72172556-c38bef80-33d5-11ea-8414-d52cbd745fab.png)

_PS: it only shows up in HTML reporter if we raise the spdx-analyzer `trustlevel`. Created #395 to improve this behavior._

Originally from #389