### PR TITLE
[database] Return file node hash

### DIFF
--- a/lib/go-qmstr/database/packageNode.go
+++ b/lib/go-qmstr/database/packageNode.go
@@ -136,6 +136,9 @@ func (db *DataBase) GetPackageTargets(pkgNodeID string) ([]*service.FileNode, er
 				uid
 				name
 				path
+				fileData {
+					hash
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Update the query to also return the file hash from FileDataNode


fix #447