### PR TITLE
Update python version

### DIFF
--- a/modules/analyzers/spdx-analyzer/spdxanalyzer/__main__.py
+++ b/modules/analyzers/spdx-analyzer/spdxanalyzer/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 import argparse
 from qmstr.service.datamodel_pb2 import InfoNode, PackageNode
 from qmstr.service.analyzerservice_pb2 import InfoNodesMessage, DummyRequest


### PR DESCRIPTION
Remove python2 from spdx-analyzer.

Even though we are using an old version of the python spdx-tool lib (v0.5.4) as a dependency, we don't need python 2 anymore because all indirect dependencies were updated to support python 3+.



<br>
fix #453 