### PR TITLE
Feat/config env override

### DIFF
--- a/lib/go-qmstr/cli/start.go
+++ b/lib/go-qmstr/cli/start.go
@@ -59,12 +59,15 @@ func getConfig() (*config.MasterConfig, error) {
 		return nil, err
 	}
 
-	config, err := config.ReadConfigFromFiles(globalHostConfigPath, configFile)
+	masterconfig, err := config.ReadConfigFromFiles(globalHostConfigPath, configFile)
 	if err != nil {
 		return nil, err
 	}
+	if err = config.ValidateConfig(masterconfig); err != nil {
+		Log.Fatalf("Config validation failed: %v", err)
+	}
 
-	return config, nil
+	return masterconfig, nil
 }
 
 func startMaster(cmd *cobra.Command, args []string) {

--- a/lib/go-qmstr/config/config.go
+++ b/lib/go-qmstr/config/config.go
@@ -147,7 +147,7 @@ func CreateProjectNode(masterConfig *MasterConfig) *service.ProjectNode {
 
 // Overrides parts of the master configuration with environment variable
 // values.
-func ConfigEnvOverride(masterConfig *MasterConfig) error {
+func ConfigEnvOverride(masterConfig *MasterConfig) {
 	if dbaddress := os.Getenv("SERVER_DBADDRESS"); dbaddress != "" {
 		masterConfig.Server.DBAddress = dbaddress
 	}
@@ -157,5 +157,4 @@ func ConfigEnvOverride(masterConfig *MasterConfig) error {
 	if buildpath := os.Getenv("SERVER_BUILDPATH"); buildpath != "" {
 		masterConfig.Server.BuildPath = buildpath
 	}
-	return nil
 }

--- a/lib/go-qmstr/config/config.go
+++ b/lib/go-qmstr/config/config.go
@@ -144,3 +144,18 @@ func CreateProjectNode(masterConfig *MasterConfig) *service.ProjectNode {
 
 	return projectNode
 }
+
+// Overrides parts of the master configuration with environment variable
+// values.
+func ConfigEnvOverride(masterConfig *MasterConfig) error {
+	if dbaddress := os.Getenv("SERVER_DBADDRESS"); dbaddress != "" {
+		masterConfig.Server.DBAddress = dbaddress
+	}
+	if rpcaddress := os.Getenv("SERVER_RPCADDRESS"); rpcaddress != "" {
+		masterConfig.Server.RPCAddress = rpcaddress
+	}
+	if buildpath := os.Getenv("SERVER_BUILDPATH"); buildpath != "" {
+		masterConfig.Server.BuildPath = buildpath
+	}
+	return nil
+}

--- a/lib/go-qmstr/config/config.go
+++ b/lib/go-qmstr/config/config.go
@@ -107,10 +107,6 @@ func readConfig(data []byte, configuration *QmstrConfig) error {
 	if err != nil {
 		return err
 	}
-	err = validateConfig(configuration.Project)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -49,7 +49,7 @@ project:
 	}
 	err = ValidateConfig(masterconf)
 	if err != nil {
-		t.Log("Config validation failed: ", err)
+		t.Logf("Config validation failed: %v", err)
 		t.Fail()
 	}
 	for _, ana := range masterconf.Analysis {

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -351,7 +351,7 @@ project:
 	if masterConfig.Server.DBAddress != os.Getenv("SERVER_DBADDRESS") ||
 		masterConfig.Server.RPCAddress != os.Getenv("SERVER_RPCADDRESS") ||
 		masterConfig.Server.BuildPath != os.Getenv("SERVER_BUILDPATH") {
-		t.Log("Configuration override failed:")
+		t.Log("Configuration override failed.")
 		t.Fail()
 	}
 }

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -332,7 +332,12 @@ project:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfigFromBytes([]byte(config))
+	masterconfig, err := ReadConfigFromBytes([]byte(config))
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+	err = ValidateConfig(masterconfig)
 	if err == nil || err.Error() != "Invalid RPC address" {
 		t.Log(err)
 		t.Fail()

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -50,6 +50,7 @@ project:
 
 	for _, ana := range masterconf.Analysis {
 		if ana.TrustLevel == 0 {
+			t.Logf("Analyzer trust level is 0: %s", ana.Name)
 			t.Fail()
 		}
 	}
@@ -98,7 +99,12 @@ project:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfigFromBytes([]byte(config))
+	masterconfig, err := ReadConfigFromBytes([]byte(config))
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+	err = ValidateConfig(masterconfig)
 	if err == nil || err.Error() != "1. reporter misconfigured Name invalid" {
 		t.Log(err)
 		t.Fail()

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -148,7 +148,12 @@ project:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfigFromBytes([]byte(config))
+	masterconfig, err := ReadConfigFromBytes([]byte(config))
+	if err != nil {
+		t.Log(err)
+	}
+
+	err = ValidateConfig(masterconfig)
 	if err == nil || err.Error() != "2. analyzer misconfigured duplicate value of The Testalyzer in Name" {
 		t.Log(err)
 		t.Fail()

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -243,7 +243,12 @@ project:
     - config:
         tester: "Endocode"
 `
-	_, err := ReadConfigFromBytes([]byte(config))
+	masterconfig, err := ReadConfigFromBytes([]byte(config))
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+	err = ValidateConfig(masterconfig)
 	if err == nil || err.Error() != "1. reporter misconfigured Name invalid" {
 		t.Log(err)
 		t.Fail()
@@ -287,7 +292,12 @@ project:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfigFromBytes([]byte(config))
+	masterconfig, err := ReadConfigFromBytes([]byte(config))
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+	err = ValidateConfig(masterconfig)
 	if err == nil || err.Error() != "2. analyzer misconfigured duplicate value of The_Testalyzer in PosixName" {
 		t.Log(err)
 		t.Fail()

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -1,8 +1,8 @@
 package config
 
 import (
+	"os"
 	"testing"
-  "os"
 )
 
 func TestCompleteConfig(t *testing.T) {
@@ -315,7 +315,7 @@ project:
 
 func TestConfigEnvOverride(t *testing.T) {
 
-  var config = `
+	var config = `
 project:
   name: "The Test"
   metadata:
@@ -341,18 +341,17 @@ project:
       config:
         tester: "Endocode"
 `
-  os.Setenv("SERVER_DBADDRESS", "override:12345")
-  os.Setenv("SERVER_RPCADDRESS", ":54321")
-  os.Setenv("SERVER_BUILDPATH", "/override")
+	os.Setenv("SERVER_DBADDRESS", "override:12345")
+	os.Setenv("SERVER_RPCADDRESS", ":54321")
+	os.Setenv("SERVER_BUILDPATH", "/override")
 
-  masterConfig, _ := ReadConfigFromBytes([]byte(config))
-  ConfigEnvOverride(masterConfig)
+	masterConfig, _ := ReadConfigFromBytes([]byte(config))
+	ConfigEnvOverride(masterConfig)
 
-  if masterConfig.Server.DBAddress != os.Getenv("SERVER_DBADDRESS") ||
-    masterConfig.Server.RPCAddress != os.Getenv("SERVER_RPCADDRESS") ||
-    masterConfig.Server.BuildPath != os.Getenv("SERVER_BUILDPATH") {
-    t.Log("Configuration override failed:")
-    t.Fail()
-  }
+	if masterConfig.Server.DBAddress != os.Getenv("SERVER_DBADDRESS") ||
+		masterConfig.Server.RPCAddress != os.Getenv("SERVER_RPCADDRESS") ||
+		masterConfig.Server.BuildPath != os.Getenv("SERVER_BUILDPATH") {
+		t.Log("Configuration override failed:")
+		t.Fail()
+	}
 }
-

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -196,7 +196,12 @@ project:
       config:
         tester: "Endocode"
 `
-	_, err := ReadConfigFromBytes([]byte(config))
+	masterconfig, err := ReadConfigFromBytes([]byte(config))
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+	err = ValidateConfig(masterconfig)
 	if err == nil || err.Error() != "1. analyzer misconfigured Analyzer invalid" {
 		t.Log(err)
 		t.Fail()

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -47,7 +47,11 @@ project:
 		t.Logf("Broken config %v", err)
 		t.FailNow()
 	}
-
+	err = ValidateConfig(masterconf)
+	if err != nil {
+		t.Log("Config validation failed: ", err)
+		t.Fail()
+	}
 	for _, ana := range masterconf.Analysis {
 		if ana.TrustLevel == 0 {
 			t.Logf("Analyzer trust level is 0: %s", ana.Name)

--- a/lib/go-qmstr/config/validation.go
+++ b/lib/go-qmstr/config/validation.go
@@ -9,7 +9,7 @@ import (
 	"github.com/QMSTR/qmstr/lib/go-qmstr/common"
 )
 
-func validateConfig(configuration *MasterConfig) error {
+func ValidateConfig(configuration *MasterConfig) error {
 	if configuration == nil {
 		return fmt.Errorf("empty configuration -- check indentation")
 	}
@@ -79,7 +79,7 @@ func validateFields(structure interface{}, uniqueFields map[string]map[string]st
 
 // GetRPCPort returns the configured port for qmstr's grpc service
 func (mc *MasterConfig) GetRPCPort() (string, error) {
-	err := validateConfig(mc)
+	err := ValidateConfig(mc)
 	if err != nil {
 		return "", err
 	}

--- a/masterserver/qmstr-master.go
+++ b/masterserver/qmstr-master.go
@@ -20,6 +20,10 @@ func main() {
 		log.Fatalf("Failed to read configuration %v", err)
 	}
 
+	if err = config.ConfigEnvOverride(&masterConfig); err != nil {
+		log.Errorf("Configuration override failed: %v", err)
+	}
+
 	if pathSubstitution != nil {
 		if len(pathSubstitution)%2 != 0 {
 			log.Fatalln("Path substitution provided via commandline is invalid")

--- a/masterserver/qmstr-master.go
+++ b/masterserver/qmstr-master.go
@@ -20,9 +20,7 @@ func main() {
 		log.Fatalf("Failed to read configuration %v", err)
 	}
 
-	if err = config.ConfigEnvOverride(&masterConfig); err != nil {
-		log.Errorf("Configuration override failed: %v", err)
-	}
+	config.ConfigEnvOverride(masterConfig)
 
 	if pathSubstitution != nil {
 		if len(pathSubstitution)%2 != 0 {

--- a/masterserver/qmstr-master.go
+++ b/masterserver/qmstr-master.go
@@ -22,6 +22,10 @@ func main() {
 
 	config.ConfigEnvOverride(masterConfig)
 
+	if err := config.ValidateConfig(masterConfig); err != nil {
+		log.Fatalf("Config validation failed: %v\n", err)
+	}
+
 	if pathSubstitution != nil {
 		if len(pathSubstitution)%2 != 0 {
 			log.Fatalln("Path substitution provided via commandline is invalid")


### PR DESCRIPTION
Adds the option to provide selected configuration directives as environment variables to the qmstr-master application. The directives are:

* SERVER_RPCADDRESS
* SERVER_DBADDRESS
* SERVER_BUILDPATH

This should make deployments in different environments easier since we don't have to modify the qmstr.yaml file in each case.
In order to guarantee that validation is running properly, the function validateConfig() has been exposed (now: ValidateConfig()) and is run not inside the readConfig() but after ConfigEnvOverride() in the source file qmstr-master.go.
All test cases are adapted to this change and a separate test case is added for the ConfigEnvOverride() functionality.