### PR TITLE
Fix/adjust test analyzer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,23 +53,7 @@ pipeline {
                         sh 'cd demos && make guava'
                     }
                 }
-
-                stage('compile openssl'){
-
-                    agent { label 'docker' }
-
-                    environment {
-                        PATH = "$PATH:$WORKSPACE/out/"
-                    }
-
-                    steps {
-                        unstash 'executables'
-                        sh 'make container'
-                        sh 'git submodule update --init'
-                        sh "cd demos && make openssl"
-                    }
-                }
-                
+                                
                 stage('compile flask'){
 
                     agent { label 'docker' }

--- a/lib/go-qmstr/config/config.go
+++ b/lib/go-qmstr/config/config.go
@@ -107,6 +107,7 @@ func readConfig(data []byte, configuration *QmstrConfig) error {
 	if err != nil {
 		return err
 	}
+	configEnvOverride(configuration.Project)
 	err = validateConfig(configuration.Project)
 	if err != nil {
 		return err
@@ -143,4 +144,16 @@ func CreateProjectNode(masterConfig *MasterConfig) *service.ProjectNode {
 	}
 
 	return projectNode
+}
+
+func configEnvOverride(masterConfig *MasterConfig) {
+	if dbaddress := os.Getenv("SERVER_DBADDRESS"); dbaddress != "" {
+		masterConfig.Server.DBAddress = dbaddress
+	}
+	if rpcaddress := os.Getenv("SERVER_RPCADDRESS"); rpcaddress != "" {
+		masterConfig.Server.RPCAddress = rpcaddress
+	}
+	if buildpath := os.Getenv("SERVER_BUILDPATH"); buildpath != "" {
+		masterConfig.Server.BuildPath = buildpath
+	}
 }

--- a/lib/go-qmstr/config/config_test.go
+++ b/lib/go-qmstr/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 )
 
@@ -308,6 +309,48 @@ project:
 	_, err := ReadConfigFromBytes([]byte(config))
 	if err == nil || err.Error() != "Invalid RPC address" {
 		t.Log(err)
+		t.Fail()
+	}
+}
+
+func TestConfigEnvOverride(t *testing.T) {
+
+	var config = `
+project:
+  name: "The Test"
+  metadata:
+    Vendor: "Endocode"
+    OcFossLiaison: "Mirko Boehm"
+    OcComplianceContact: "foss@endocode.com"
+  server:
+    rpcaddress: ":12345"
+    dbaddress: "testhost:54321"
+    dbworkers: 4
+  analysis:
+    - analyzer: test-analyzer
+      name: "The Testalyzer"
+      selector: sourcecode
+      pathsub:
+        - old: "/the/path"
+          new: "/buildroot"
+      config:
+        workdir: "/buildroot"
+  reporting:
+    - reporter: test-reporter
+      name: "The test reporter"
+      config:
+        tester: "Endocode"
+`
+	os.Setenv("SERVER_DBADDRESS", "override:12345")
+	os.Setenv("SERVER_RPCADDRESS", ":54321")
+	os.Setenv("SERVER_BUILDPATH", "/override")
+
+	masterConfig, _ := ReadConfigFromBytes([]byte(config))
+
+	if masterConfig.Server.DBAddress != os.Getenv("SERVER_DBADDRESS") ||
+		masterConfig.Server.RPCAddress != os.Getenv("SERVER_RPCADDRESS") ||
+		masterConfig.Server.BuildPath != os.Getenv("SERVER_BUILDPATH") {
+		t.Log("Configuration override failed.")
 		t.Fail()
 	}
 }

--- a/modules/analyzers/test-analyzer/main.go
+++ b/modules/analyzers/test-analyzer/main.go
@@ -57,7 +57,7 @@ func (testanalyzer *TestAnalyzer) Analyze(masterClient *module.MasterClient, tok
 			if test == "TestPackageNode" {
 				testfunction = TestPackageNode
 			} else if test == "TestCalcBuildGraph" {
-				expectedTargets = []string{"Calculator/calc", "Calculator/libcalc.so", "Calculator/libcalc.a", "Calculator/calcs"}
+				expectedTargets = []string{"calc", "libcalc.so", "libcalc.a", "calcs"}
 				testfunction = TestBuildGraph
 			} else if test == "TestCurlBuildGraph" {
 				expectedTargets = []string{"curl/build/src/curl", "curl/build/lib/libcurl.so"}


### PR DESCRIPTION
Using a generic name for the client's buildroot increases usability/convenience for switching between compose demos.
This requires that the test-analyzer is checking the right directory.
Confirmed running via docker compose demo:
```
...
2020/03/11 11:00:14 Event: MODULE, Message: Running analyzer test-analyzer
2020/03/11 11:00:14 Event: MODULE, Message: Analyzer test-analyzer successfully finished
2020/03/11 11:00:14 Event: PHASE, Message: Switched to phase 2
```