### PR TITLE
Use generic name buildroot for buildroot

### DIFF
--- a/modules/analyzers/test-analyzer/main.go
+++ b/modules/analyzers/test-analyzer/main.go
@@ -57,7 +57,7 @@ func (testanalyzer *TestAnalyzer) Analyze(masterClient *module.MasterClient, tok
 			if test == "TestPackageNode" {
 				testfunction = TestPackageNode
 			} else if test == "TestCalcBuildGraph" {
-				expectedTargets = []string{"Calculator/calc", "Calculator/libcalc.so", "Calculator/libcalc.a", "Calculator/calcs"}
+				expectedTargets = []string{"calc", "libcalc.so", "libcalc.a", "calcs"}
 				testfunction = TestBuildGraph
 			} else if test == "TestCurlBuildGraph" {
 				expectedTargets = []string{"curl/build/src/curl", "curl/build/lib/libcurl.so"}


### PR DESCRIPTION
The test analyzer is checking for the old paths and directory structure. Changed it to work with the compose demo 'calc'. Output:

```
[INFO] Connected to master.
[INFO] Cleaning codebase.
rm -rf add.o subtract.o multiply.o devide.o calc calcs punktrechnung.o *.so *.a
/home/calc/buildroot
master:50051


###########################
# Running Calculator demo #
###########################
gcc -nostartfiles -static-libgcc -fPIC -r -o punktrechnung.o multiply.c devide.c
gcc -shared -fPIC -o libcalc.so add.c subtract.c punktrechnung.o
gcc main.c -o calc -L. -lcalc -ljson-c
strip -s calc
gcc -c add.c subtract.c multiply.c devide.c
ar rcs libcalc.a add.o subtract.o multiply.o devide.o
gcc -static main.c -o calcs libcalc.a -ljson-c
[INFO] Build finished.
DEBUG: 2020/03/11 11:23:14 Connection to control service at master:50051 set up
2020/03/11 11:23:14 Event: PHASE, Message: Switching to phase 2
2020/03/11 11:23:16 Event: PHASE, Message: Activating analysis phase
2020/03/11 11:23:16 Event: MODULE, Message: Running analyzer spdx-identifier-analyzer
2020/03/11 11:23:17 Event: MODULE, Message: Analyzer spdx-identifier-analyzer successfully finished
2020/03/11 11:23:17 Event: MODULE, Message: Running analyzer test-analyzer
2020/03/11 11:23:17 Event: MODULE, Message: Analyzer test-analyzer successfully finished
2020/03/11 11:23:17 Event: PHASE, Message: Switched to phase 2
[INFO] Analysis finished.
```