### PR TITLE
Html reporter should not fail when there are no package nodes 

### DIFF
--- a/modules/reporters/qmstr-reporter-html/htmlreporter.go
+++ b/modules/reporters/qmstr-reporter-html/htmlreporter.go
@@ -118,6 +118,10 @@ func (r *HTMLReporter) Report(masterClient *module.MasterClient) error {
 	}
 
 	pnps, err := masterClient.GetPackageNodes()
+	if len(pnps) < 1 {
+		log.Println("WARNING:No Package node found")
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to get package node: %v", err)
 	}


### PR DESCRIPTION
We had this check before but this commit removed it: https://github.com/QMSTR/qmstr/pull/441/commits/82506319ad31b76d078040d184387751dcf10549

<img width="2217" alt="Screen Shot 2020-04-07 at 5 51 28 PM" src="https://user-images.githubusercontent.com/22662614/78691110-8f529d00-78f8-11ea-90ad-9a2d9811deee.png">
