### PR TITLE
Strip qmstr-master image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+./out/
+./doc/
+./ci/
+./venv/
+./Jenkinsfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 ./out/
 ./doc/
-./ci/
 ./venv/
 ./Jenkinsfile

--- a/docker/qmstr-master/Dockerfile
+++ b/docker/qmstr-master/Dockerfile
@@ -1,0 +1,47 @@
+################################################################################
+# STAGE 1: Build master binaries                                               #
+################################################################################
+ARG GOBUILDER_IMAGE=golang:1.12-buster
+
+FROM $GOBUILDER_IMAGE as gobuilder
+ENV GOPROXY="https://proxy.golang.org"
+
+RUN set -e && \
+  apt update && \
+  apt install -y protobuf-compiler && \
+  mkdir /root/qmstr/
+
+WORKDIR /root/qmstr
+
+COPY ./ ./
+
+RUN set -e && \
+  go build -o ./out/qmstr-master ./masterserver/
+
+################################################################################
+# STAGE 2: Build master container image (deploy)                               #
+################################################################################
+
+FROM debian:buster-slim as deploy
+
+# Required QMSTR directories
+ENV QMSTR_DIRS="/var/qmstr/ /var/cache/qmstr/ /var/lib/qmstr/"
+
+# Copy binaries from build stage
+COPY --from=gobuilder /root/qmstr/out/* /usr/local/bin/
+
+RUN set -e && \
+  addgroup qmstr && \
+  adduser --system qmstr --ingroup qmstr && \
+  mkdir -p ${QMSTR_DIRS} && \
+  chown -R qmstr ${QMSTR_DIRS}
+
+WORKDIR /home/qmstr
+USER qmstr
+
+EXPOSE 50051
+
+VOLUME /home/qmstr/config
+VOLUME /home/qmstr/buildroot
+
+ENTRYPOINT ["/usr/local/bin/qmstr-master"]


### PR DESCRIPTION
Provides a minimal qmstr-master docker image to be used in later stages (i.e. by new CI, Kubernetes manifests, etc.).
To verify basic functionality, provide a qmstr.yaml configuration either as docker command or k8s argument and reference an accessible dgraph endpoint.
E.g.:
```bash
# build master image
docker build -f docker/qmstr-master/Dockerfile -t qmstr/master:latest .
cd /tmp
# create minimal config, otherwise the master process won't start
mkdir ./config
cat << EOF > /tmp/config/qmstr.yaml
project:
  name: "HelloWorld"
  metadata: 
    message: "Hello World!" 
EOF
# create docker-compose file
cat << EOF > docker-compose.yaml
version: "3.7"
services:
  dgraph:
    image: dgraph/standalone:latest
    ports:
      - 9080:9080
    networks:
      - qmstr
  master:
    image: qmstr/master
    depends_on:
      - dgraph
    ports:
      - 50051:50051
    networks:
      - qmstr
    environment:
      SERVER_DBADDRESS: dgraph:9080
    volumes:
      - /tmp/config:/home/qmstr/config
    command: ["--config", "/home/qmstr/config/qmstr.yaml"]
networks:
  qmstr:
EOF

# run compose stack
docker-compose up -d
# check logs
docker-compose logs -f | grep master
```

In further iterations/PRs those tests will be automated in a more convenient fashion.
