### PR TITLE
Removed invalid `install` -t flag for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,10 @@ install: install_qmstr_client
 
 # Installation targets
 install_qmstr_server: $(QMSTR_SERVER_BINARIES)
-	install -t $(prefix)/bin $^
+	install $^ $(prefix)/bin
 
 install_qmstr_client: $(QMSTR_CLIENT_BINARIES)
-	install -t $(prefix)/bin $^
+	install $^ $(prefix)/bin
 
 install_qmstr_all: install_qmstr_client install_qmstr_server
 


### PR DESCRIPTION
The `-t` flag for the `install` command is not available on macOS.
I'm hence adopting:
```bash
install [OPTION]... SOURCE... DIRECTORY
```
Instead of:
```bash
install [OPTION]... -t DIRECTORY SOURCE...
```
([source](https://linux.die.net/man/1/install)).