### PR TITLE
Removing double quotes before resolving paths

### DIFF
--- a/lib/go-qmstr/common/fileutil.go
+++ b/lib/go-qmstr/common/fileutil.go
@@ -60,6 +60,17 @@ func SetRelativePath(node *service.FileNode, buildPath string, pathSub []*servic
 	if !filepath.IsAbs(node.Path) {
 		return nil
 	}
+
+	// Removing double quotes around paths
+	for _, s := range []*string{&buildPath, &node.Path} {
+		if len(*s) > 0 && (*s)[0] == '"' {
+			*s = (*s)[1:]
+		}
+		if len(*s) > 0 && (*s)[len(*s)-1] == '"' {
+			*s = (*s)[:len(*s)-1]
+		}
+	}
+
 	relPath, err := filepath.Rel(buildPath, node.Path)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
When using Docker volumes for the build root, [`filepath.Rel()`](https://golang.org/pkg/path/filepath/#Rel) fails as `targpath` contains double-quotes.

This PR removes double quotes if there are any.